### PR TITLE
pbs-77--fix: quality domain crud 수정

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/request/QualityCreateRequestDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/request/QualityCreateRequestDTO.java
@@ -6,14 +6,14 @@ import com.pobluesky.backend.domain.quality.entity.QualityReviewInfo;
 
 public record QualityCreateRequestDTO(
     QualityReviewInfo qualityReviewInfo,
-    String requireAddContents
+    String qualityComments
 ) {
     // dto -> entity
     public Quality toQualityEntity(Inquiry inquiry) {
         return Quality.builder()
             .inquiry(inquiry)
             .qualityReviewInfo(qualityReviewInfo)
-            .requireAddContents(requireAddContents)
+            .qualityComments(qualityComments)
             .build();
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/request/QualityUpdateRequestDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/request/QualityUpdateRequestDTO.java
@@ -4,6 +4,6 @@ import com.pobluesky.backend.domain.quality.entity.QualityReviewInfo;
 
 public record QualityUpdateRequestDTO(
     QualityReviewInfo qualityReviewInfo,
-    String requireAddContents
+    String qualityComments
 ) {
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/response/QualityResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/response/QualityResponseDTO.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 public record QualityResponseDTO(
     Long qualityId,
     Long inquiryId,
-    Long userId,
     QualityReviewInfo qualityReviewInfo,
     String requireAddContents
 ) {

--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/response/QualityResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/dto/response/QualityResponseDTO.java
@@ -9,7 +9,7 @@ public record QualityResponseDTO(
     Long qualityId,
     Long inquiryId,
     QualityReviewInfo qualityReviewInfo,
-    String requireAddContents
+    String qualityComments
 ) {
     // entity -> dto
     public static QualityResponseDTO from(Quality quality) {
@@ -17,7 +17,7 @@ public record QualityResponseDTO(
             .qualityId(quality.getQualityId())
             .inquiryId(quality.getInquiry().getInquiryId())
             .qualityReviewInfo(quality.getQualityReviewInfo())
-            .requireAddContents(quality.getRequireAddContents())
+            .qualityComments(quality.getQualityComments())
             .build();
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/entity/Quality.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/entity/Quality.java
@@ -1,6 +1,7 @@
 package com.pobluesky.backend.domain.quality.entity;
 
 import com.pobluesky.backend.domain.inquiry.entity.Inquiry;
+import com.pobluesky.backend.global.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "quality")
 @NoArgsConstructor
 @AllArgsConstructor
-public class Quality {
+public class Quality extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long qualityId; // 품질번호

--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/entity/Quality.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/entity/Quality.java
@@ -34,7 +34,7 @@ public class Quality extends BaseEntity {
     private QualityReviewInfo qualityReviewInfo; // 품질검토정보
 
     @Column(columnDefinition = "TEXT")
-    private String requireAddContents; // 추가요청내용
+    private String qualityComments; // 추가요청내용
     /*
       Builder Pattern
      */
@@ -42,17 +42,17 @@ public class Quality extends BaseEntity {
     private Quality(
         Inquiry inquiry,
         QualityReviewInfo qualityReviewInfo,
-        String requireAddContents
+        String qualityComments
     ) {
         this.inquiry = inquiry;
         this.qualityReviewInfo = qualityReviewInfo;
-        this.requireAddContents = requireAddContents;
+        this.qualityComments = qualityComments;
     }
     public void updateQuality(
         QualityReviewInfo qualityReviewInfo,
         String requireAddContents
     ) {
         this.qualityReviewInfo = qualityReviewInfo;
-        this.requireAddContents = requireAddContents;
+        this.qualityComments = qualityComments;
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/quality/service/QualityService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/quality/service/QualityService.java
@@ -50,7 +50,7 @@ public class QualityService {
 
         quality.updateQuality(
             qualityUpdateRequestDTO.qualityReviewInfo(),
-            qualityUpdateRequestDTO.requireAddContents()
+            qualityUpdateRequestDTO.qualityComments()
         );
 
         return QualityResponseDTO.from(quality);

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -37,7 +37,7 @@ VALUES
     (3, 'Steel Rod', 'Spec DEF', 'Brushed', 'Manufacturing', '2.5mm', '550mm', '1650mm', '1200 units', '60000', '1000kg', '1100kg', 'Beveled', 'EXW 10', 'Net 60', '2023-11-01', '2024-02-28', 'Factory C', 'Subject to mill’s final confirmation3');
 
 -- Quality
-INSERT INTO quality (inquiry_id, final_result, final_result_details, standard, order_category, coating_metal_quantity, coating_oil_quantity, thickness_tolerance, order_edge, customerqreq, available_lab, require_add_contents)
+INSERT INTO quality (inquiry_id, final_result, final_result_details, standard, order_category, coating_metal_quantity, coating_oil_quantity, thickness_tolerance, order_edge, customerqreq, available_lab, quality_comments)
 VALUES
     (1, 'Passed', 'All tests passed successfully', 1, 'Category A', '10g/m2', '5g/m2', '±0.1mm', 'Smooth', 'Customer Quality Requirement 1', true, 'Additional requirement details 1'),
     (2, 'Failed', 'Some tests failed, see details', 2, 'Category B', '15g/m2', '7g/m2', '±0.2mm', 'Rough', 'Customer Quality Requirement 2', false, 'Additional requirement details 2'),


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - QualityResponseDTO의 userId 필드 제거
  - Quality entity BaseEntity 상속 추가
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
<br>