### PR TITLE
Be hotfix#203  pjh question sorting fix

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepositoryCustom.java
@@ -15,6 +15,7 @@ public interface CollaborationRepositoryCustom {
         String colReqManager,
         Long colReqId,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        String sortBy
     );
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/service/CollaborationService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/service/CollaborationService.java
@@ -54,9 +54,15 @@ public class CollaborationService {
 
     @Transactional(readOnly = true)
     public Page<CollaborationSummaryResponseDTO> getAllCollaborations(
-        String token, int page, int size, String sortBy,
-        ColStatus colStatus, String colReqManager, Long colReqId,
-        LocalDate startDate, LocalDate endDate
+        String token,
+        int page,
+        int size,
+        String sortBy,
+        ColStatus colStatus,
+        String colReqManager,
+        Long colReqId,
+        LocalDate startDate,
+        LocalDate endDate
     ) {
         Long userId = signService.parseToken(token);
 
@@ -66,12 +72,16 @@ public class CollaborationService {
         if(manager.getRole() == UserRole.CUSTOMER)
             throw new CommonException(ErrorCode.UNAUTHORIZED_USER_MANAGER);
 
-        Sort sort = getSortByOrderCondition(sortBy);
-        Pageable pageable = PageRequest.of(page, size, sort);
+        Pageable pageable = PageRequest.of(page, size);
 
         return collaborationRepository.findAllCollaborationsRequest(
-            pageable, colStatus, colReqManager, colReqId,
-            startDate, endDate
+            pageable,
+            colStatus,
+            colReqManager,
+            colReqId,
+            startDate,
+            endDate,
+            sortBy
         );
     }
 
@@ -216,21 +226,5 @@ public class CollaborationService {
         }
 
         return collaboration;
-    }
-
-    private Sort getSortByOrderCondition(String sortBy) {
-        return switch (sortBy) {
-            case "OLDEST" -> Sort.by(
-                Sort.Order.asc("createdDate"),
-                Sort.Order.desc("colId")
-            );
-
-            case "LATEST" -> Sort.by(
-                Sort.Order.desc("createdDate"),
-                Sort.Order.desc("colId")
-            );
-
-            default -> throw new CommonException(ErrorCode.INVALID_ORDER_CONDITION);
-        };
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryRepositoryCustom.java
@@ -19,7 +19,8 @@ public interface InquiryRepositoryCustom {
         String customerName,
         InquiryType inquiryType,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        String sortBy
     );
 
     Page<InquirySummaryResponseDTO> findInquiriesByManager(
@@ -29,6 +30,7 @@ public interface InquiryRepositoryCustom {
         String customerName,
         InquiryType inquiryType,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        String sortBy
     );
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -33,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -77,12 +76,7 @@ public class InquiryService {
         if(!Objects.equals(customer.getUserId(), customerId))
             throw new CommonException(ErrorCode.USER_NOT_MATCHED);
 
-        Sort sort = getSortByOrderCondition(sortBy);
-        Pageable pageable = PageRequest.of(
-            page,
-            size,
-            sort
-        );
+        Pageable pageable = PageRequest.of(page, size);
 
         return inquiryRepository.findInquiriesByCustomer(
             customerId,
@@ -92,7 +86,8 @@ public class InquiryService {
             customerName,
             inquiryType,
             startDate,
-            endDate
+            endDate,
+            sortBy
         );
     }
 
@@ -117,12 +112,7 @@ public class InquiryService {
         if(manager.getRole() == UserRole.CUSTOMER)
             throw new CommonException(ErrorCode.UNAUTHORIZED_USER_MANAGER);
 
-        Sort sort = getSortByOrderCondition(sortBy);
-        Pageable pageable = PageRequest.of(
-            page,
-            size,
-            sort
-        );
+        Pageable pageable = PageRequest.of(page, size);
 
         return inquiryRepository.findInquiriesByManager(
             pageable,
@@ -131,7 +121,8 @@ public class InquiryService {
             customerName,
             inquiryType,
             startDate,
-            endDate
+            endDate,
+            sortBy
         );
     }
 
@@ -281,21 +272,5 @@ public class InquiryService {
             lineItemService.getFullLineItemsByInquiry(inquiryId);
 
         return InquiryResponseDTO.of(inquiry, lineItemsByInquiry);
-    }
-
-    private Sort getSortByOrderCondition(String sortBy) {
-        return switch (sortBy) {
-            case "OLDEST" -> Sort.by(
-                Sort.Order.asc("createdDate"),
-                Sort.Order.desc("inquiryId")
-            );
-
-            case "LATEST" -> Sort.by(
-                Sort.Order.desc("createdDate"),
-                Sort.Order.desc("inquiryId")
-            );
-
-            default -> throw new CommonException(ErrorCode.INVALID_ORDER_CONDITION);
-        };
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
@@ -10,10 +10,10 @@ import org.springframework.data.domain.Pageable;
 public interface QuestionRepositoryCustom {
     QuestionSummaryResponseDTO findQuestionsByCustomer(
         Long userId, Pageable pageable, QuestionStatus status,
-        LocalDate startDate, LocalDate endDate);
+        LocalDate startDate, LocalDate endDate, String sortBy);
 
     QuestionSummaryResponseDTO findQuestionsByManager(
         Pageable pageable, QuestionStatus status,
-        LocalDate startDate, LocalDate endDate
+        LocalDate startDate, LocalDate endDate, String sortBy
     );
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
@@ -9,11 +9,18 @@ import org.springframework.data.domain.Pageable;
 
 public interface QuestionRepositoryCustom {
     QuestionSummaryResponseDTO findQuestionsByCustomer(
-        Long userId, Pageable pageable, QuestionStatus status,
-        LocalDate startDate, LocalDate endDate, String sortBy);
+        Long userId,
+        Pageable pageable,
+        QuestionStatus status,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy);
 
     QuestionSummaryResponseDTO findQuestionsByManager(
-        Pageable pageable, QuestionStatus status,
-        LocalDate startDate, LocalDate endDate, String sortBy
+        Pageable pageable,
+        QuestionStatus status,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
     );
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryImpl.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryImpl.java
@@ -166,6 +166,23 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
             .fetch();
     }
 
+    private OrderSpecifier<?>[] getOrderSpecifier(String sortBy) {
+        switch (sortBy) {
+            case "LATEST":
+                return new OrderSpecifier[]{
+                    question.createdDate.desc().nullsLast(),
+                    question.questionId.desc()
+                };
+            case "OLDEST":
+                return new OrderSpecifier[]{
+                    question.createdDate.asc().nullsFirst(),
+                    question.questionId.asc()
+                };
+            default:
+                throw new CommonException(ErrorCode.INVALID_ORDER_CONDITION);
+        }
+    }
+
     private BooleanExpression statusEq(QuestionStatus status) {
         return status != null ? question.status.eq(status) : null;
     }
@@ -187,23 +204,6 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
             return dateTemplate.goe(startDate);
         } else {
             return dateTemplate.loe(endDate);
-        }
-    }
-
-    private OrderSpecifier<?>[] getOrderSpecifier(String sortBy) {
-        switch (sortBy) {
-            case "LATEST":
-                return new OrderSpecifier[]{
-                    question.createdDate.desc().nullsLast(),
-                    question.questionId.desc()
-                };
-            case "OLDEST":
-                return new OrderSpecifier[]{
-                    question.createdDate.asc().nullsFirst(),
-                    question.questionId.asc()
-                };
-            default:
-                throw new CommonException(ErrorCode.INVALID_ORDER_CONDITION);
         }
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -64,7 +63,12 @@ public class QuestionService {
 
         Pageable pageable = PageRequest.of(page, size);
 
-        return questionRepository.findQuestionsByManager(pageable, status, startDate, endDate, sortBy);
+        return questionRepository.findQuestionsByManager(
+            pageable,
+            status,
+            startDate,
+            endDate,
+            sortBy);
     }
 
     // 질문 전체 조회 (고객사)
@@ -91,7 +95,12 @@ public class QuestionService {
         Pageable pageable = PageRequest.of(page, size);
 
         return questionRepository.findQuestionsByCustomer(
-            customerId, pageable, status, startDate, endDate, sortBy);
+            customerId,
+            pageable,
+            status,
+            startDate,
+            endDate,
+            sortBy);
     }
 
     // 질문 번호별 질문 조회 (담당자)

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
@@ -49,15 +49,19 @@ public class QuestionService {
     // 질문 전체 조회 (담당자)
     @Transactional(readOnly = true)
     public QuestionSummaryResponseDTO getQuestionsByManager(
-        String token, int page, int size, String sortBy,
-        QuestionStatus status, LocalDate startDate, LocalDate endDate) {
+        String token,
+        int page,
+        int size,
+        String sortBy,
+        QuestionStatus status,
+        LocalDate startDate,
+        LocalDate endDate) {
 
         Long userId = signService.parseToken(token);
 
         managerRepository.findById(userId)
             .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        //Sort sort = getSortByOrderCondition(sortBy);
         Pageable pageable = PageRequest.of(page, size);
 
         return questionRepository.findQuestionsByManager(pageable, status, startDate, endDate, sortBy);
@@ -66,8 +70,14 @@ public class QuestionService {
     // 질문 전체 조회 (고객사)
     @Transactional(readOnly = true)
     public QuestionSummaryResponseDTO getQuestionsByCustomer(
-        String token, Long customerId, int page, int size, String sortBy,
-        QuestionStatus status, LocalDate startDate, LocalDate endDate) {
+        String token,
+        Long customerId,
+        int page,
+        int size,
+        String sortBy,
+        QuestionStatus status,
+        LocalDate startDate,
+        LocalDate endDate) {
 
         Long userId = signService.parseToken(token);
 
@@ -78,7 +88,6 @@ public class QuestionService {
             throw new CommonException(ErrorCode.USER_NOT_MATCHED);
         }
 
-        //Sort sort = getSortByOrderCondition(sortBy);
         Pageable pageable = PageRequest.of(page, size);
 
         return questionRepository.findQuestionsByCustomer(
@@ -175,21 +184,5 @@ public class QuestionService {
         Question savedQuestion = questionRepository.save(question);
 
         return QuestionResponseDTO.from(savedQuestion);
-    }
-
-    private Sort getSortByOrderCondition(String sortBy) {
-        return switch (sortBy) {
-            case "OLDEST" -> Sort.by(
-                Sort.Order.asc("createdDate"),
-                Sort.Order.desc("questionId")
-            );
-
-            case "LATEST" -> Sort.by(
-                Sort.Order.desc("createdDate"),
-                Sort.Order.desc("questionId")
-            );
-
-            default -> throw new CommonException(ErrorCode.INVALID_ORDER_CONDITION);
-        };
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
@@ -57,10 +57,10 @@ public class QuestionService {
         managerRepository.findById(userId)
             .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        Sort sort = getSortByOrderCondition(sortBy);
-        Pageable pageable = PageRequest.of(page, size, sort);
+        //Sort sort = getSortByOrderCondition(sortBy);
+        Pageable pageable = PageRequest.of(page, size);
 
-        return questionRepository.findQuestionsByManager(pageable, status, startDate, endDate);
+        return questionRepository.findQuestionsByManager(pageable, status, startDate, endDate, sortBy);
     }
 
     // 질문 전체 조회 (고객사)
@@ -78,11 +78,11 @@ public class QuestionService {
             throw new CommonException(ErrorCode.USER_NOT_MATCHED);
         }
 
-        Sort sort = getSortByOrderCondition(sortBy);
-        Pageable pageable = PageRequest.of(page, size, sort);
+        //Sort sort = getSortByOrderCondition(sortBy);
+        Pageable pageable = PageRequest.of(page, size);
 
         return questionRepository.findQuestionsByCustomer(
-            customerId, pageable, status, startDate, endDate);
+            customerId, pageable, status, startDate, endDate, sortBy);
     }
 
     // 질문 번호별 질문 조회 (담당자)


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
- Inquiry, Question, Collaboration 조회 API 정렬 조건 수정 
    -  기존 서비스 단으로 분리한 기본 정렬(최신순/오래된 순)을 레포단으로 옮김.
    
- 변경한 이유
 서비스단에서 보내주는 정렬 조건을 레포단에서 가져오기 위해선 pagable로 넘어온 정렬 객체를 받아 처리하는 과정이 필요했습니다.
 생각한 방법은 아래와 같습니다.
   1. QuestionDslUtils 클래스 생성, 각 속성에 대한 OrderSpecifier 객체 생성 후 정렬 로직 처리
   2. 별도의 Sort 객체를 OrderSpecifier 객체로 변환하는 과정 추가
   
- 결론
 방법은 여러 가지 있긴 하겠지만, 코드가 복잡해지는 것 같아 지금 당장 정렬 조건을 돌아가게 하기 위해 모든 정렬 처리를 레포단으로 넘기는 결론을 내렸습니다. (비즈니스 분리를 위해 추후 리팩토링 의향O)
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트 - 테스트 완료 
<br>
