### PR TITLE
Be refactor#211 pjh list api fix

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
@@ -39,7 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class CollaborationController {
     private final CollaborationService collaborationService;
 
-    @GetMapping
+    @GetMapping("/all")
     @Operation(summary = "협업 목록 조회", description = "협업 요청을 받은 담당자의 협업 목록을 전부 조회한다.")
     public ResponseEntity<JsonResult> getAllCollaborations(
         @RequestHeader("Authorization") String token,
@@ -74,8 +74,8 @@ public class CollaborationController {
             .body(ResponseFactory.getSuccessJsonResult(response));
     }
 
-    @GetMapping("/all")
-    @Operation(summary = "협업 목록 조회2", description = "협업 요청을 받은 담당자의 협업 목록을 페이징 없이 전부 조회한다.")
+    @GetMapping
+    @Operation(summary = "협업 목록 조회(페이징 제외)", description = "협업 요청을 받은 담당자의 협업 목록을 페이징 없이 전부 조회한다.")
     public ResponseEntity<JsonResult> getAllCollaborationsWithoutPaging(
         @RequestHeader("Authorization") String token,
         @RequestParam(defaultValue = "LATEST") String sortBy,

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.time.LocalDate;
 import java.util.HashMap;
 
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
@@ -71,6 +72,31 @@ public class CollaborationController {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/all")
+    @Operation(summary = "협업 목록 조회2", description = "협업 요청을 받은 담당자의 협업 목록을 페이징 없이 전부 조회한다.")
+    public ResponseEntity<JsonResult> getAllCollaborationsWithoutPaging(
+        @RequestHeader("Authorization") String token,
+        @RequestParam(defaultValue = "LATEST") String sortBy,
+        @RequestParam(required = false) ColStatus colStatus,
+        @RequestParam(required = false) String colReqManager,
+        @RequestParam(required = false) Long colReqId,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        List<CollaborationSummaryResponseDTO> cols = collaborationService.getAllCollaborationsWithoutPaging(
+            token,
+            sortBy,
+            colStatus,
+            colReqManager,
+            colReqId,
+            startDate,
+            endDate
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseFactory.getSuccessJsonResult(cols));
     }
 
     @Operation(summary = "questionId 별 협업 요청")

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepositoryCustom.java
@@ -5,12 +5,22 @@ import com.pobluesky.backend.domain.collaboration.entity.ColStatus;
 
 import java.time.LocalDate;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CollaborationRepositoryCustom {
     Page<CollaborationSummaryResponseDTO> findAllCollaborationsRequest(
         Pageable pageable,
+        ColStatus colStatus,
+        String colReqManager,
+        Long colReqId,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    );
+
+    List<CollaborationSummaryResponseDTO> findAllCollaborationsRequestWithoutPaging(
         ColStatus colStatus,
         String colReqManager,
         Long colReqId,

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepositoryImpl.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepositoryImpl.java
@@ -66,6 +66,35 @@ public class CollaborationRepositoryImpl implements CollaborationRepositoryCusto
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
     }
 
+    @Override
+    public List<CollaborationSummaryResponseDTO> findAllCollaborationsRequestWithoutPaging(
+        ColStatus colStatus,
+        String colReqManager,
+        Long colReqId,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy) {
+
+        return queryFactory
+            .select(Projections.constructor(CollaborationSummaryResponseDTO.class,
+                collaboration.colId,
+                manager.name,
+                collaboration.colStatus,
+                collaboration.colContents,
+                collaboration.createdDate
+            ))
+            .from(collaboration)
+            .join(collaboration.colRequestManager, manager)
+            .where(
+                colStatusEq(colStatus),
+                colReqManagerEq(colReqManager),
+                colReqIdEq(colReqId),
+                createdDateBetween(startDate, endDate)
+            )
+            .orderBy(getOrderSpecifier(sortBy))
+            .fetch();
+    }
+
     private JPAQuery<Collaboration> getCountQuery(ColStatus colStatus, String colReqManagerName, Long colReqId,
         LocalDate startDate, LocalDate endDate) {
         return queryFactory

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/service/CollaborationService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/service/CollaborationService.java
@@ -22,6 +22,7 @@ import com.pobluesky.backend.global.error.ErrorCode;
 
 import java.time.LocalDate;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
@@ -69,6 +70,34 @@ public class CollaborationService {
 
         return collaborationRepository.findAllCollaborationsRequest(
             pageable,
+            colStatus,
+            colReqManager,
+            colReqId,
+            startDate,
+            endDate,
+            sortBy
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<CollaborationSummaryResponseDTO> getAllCollaborationsWithoutPaging(
+        String token,
+        String sortBy,
+        ColStatus colStatus,
+        String colReqManager,
+        Long colReqId,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        Long userId = signService.parseToken(token);
+
+        Manager manager = managerRepository.findById(userId)
+            .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        if(manager.getRole() == UserRole.CUSTOMER)
+            throw new CommonException(ErrorCode.UNAUTHORIZED_USER_MANAGER);
+
+        return collaborationRepository.findAllCollaborationsRequestWithoutPaging(
             colStatus,
             colReqManager,
             colReqId,

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/service/CollaborationService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/service/CollaborationService.java
@@ -46,6 +46,7 @@ public class CollaborationService {
 
     private final FileService fileService;
 
+    // 협업 조회
     @Transactional(readOnly = true)
     public Page<CollaborationSummaryResponseDTO> getAllCollaborations(
         String token,
@@ -79,6 +80,7 @@ public class CollaborationService {
         );
     }
 
+    // 협업 조회 without paging
     @Transactional(readOnly = true)
     public List<CollaborationSummaryResponseDTO> getAllCollaborationsWithoutPaging(
         String token,

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
@@ -14,6 +14,7 @@ import com.pobluesky.backend.global.util.model.JsonResult;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,7 +45,7 @@ public class InquiryController {
     private final InquiryService inquiryService;
 
     // 고객 Inquiry 조회
-    @GetMapping("/customers/inquiries/{userId}")
+    @GetMapping("/customers/inquiries/{userId}/all")
     @Operation(summary = "Inquiry 조회(고객사)", description = "등록된 모든 Inquiry를 조건에 맞게 조회한다.")
     public ResponseEntity<JsonResult> getInquiriesByCustomer(
         @RequestHeader("Authorization") String token,
@@ -81,6 +82,35 @@ public class InquiryController {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/customers/inquiries/{userId}")
+    @Operation(summary = "Inquiry 조회(고객사)", description = "등록된 모든 Inquiry를 조건에 맞게 페이징 없이 조회한다.")
+    public ResponseEntity<JsonResult> getInquiriesByCustomerWithoutPaging(
+        @RequestHeader("Authorization") String token,
+        @PathVariable Long userId,
+        @RequestParam(defaultValue = "LATEST") String sortBy,
+        @RequestParam(required = false) Progress progress,
+        @RequestParam(required = false) ProductType productType,
+        @RequestParam(required = false) String customerName,
+        @RequestParam(required = false) InquiryType inquiryType,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        List<InquirySummaryResponseDTO> inquiries = inquiryService.getInquiriesByCustomerWithoutPaging(
+            token,
+            userId,
+            sortBy,
+            progress,
+            productType,
+            customerName,
+            inquiryType,
+            startDate,
+            endDate
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseFactory.getSuccessJsonResult(inquiries));
     }
 
     // 상세 조회 페이지
@@ -150,7 +180,7 @@ public class InquiryController {
     }
 
     // 담당자 Inquiry 조회
-    @GetMapping("/managers/inquiries")
+    @GetMapping("/managers/inquiries/all")
     @Operation(summary = "Inquiry 조회(담당자)", description = "등록된 모든 Inquiry를 조건에 맞게 조회한다.")
     public ResponseEntity<JsonResult> getInquiriesByManager(
         @RequestHeader("Authorization") String token,
@@ -185,6 +215,33 @@ public class InquiryController {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/managers/inquiries")
+    @Operation(summary = "Inquiry 조회(담당자)", description = "등록된 모든 Inquiry를 조건에 맞게 페이징 없이 조회한다.")
+    public ResponseEntity<JsonResult> getInquiriesByManagerWithoutPaging(
+        @RequestHeader("Authorization") String token,
+        @RequestParam(defaultValue = "LATEST") String sortBy,
+        @RequestParam(required = false) Progress progress,
+        @RequestParam(required = false) ProductType productType,
+        @RequestParam(required = false) String customerName,
+        @RequestParam(required = false) InquiryType inquiryType,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        List<InquirySummaryResponseDTO> inquiries = inquiryService.getInquiriesByManagerWithoutPaging(
+            token,
+            sortBy,
+            progress,
+            productType,
+            customerName,
+            inquiryType,
+            startDate,
+            endDate
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseFactory.getSuccessJsonResult(inquiries));
     }
 
     // 상세 조회 페이지

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryRepositoryCustom.java
@@ -7,6 +7,7 @@ import com.pobluesky.backend.domain.inquiry.entity.Progress;
 
 import java.time.LocalDate;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -25,6 +26,27 @@ public interface InquiryRepositoryCustom {
 
     Page<InquirySummaryResponseDTO> findInquiriesByManager(
         Pageable pageable,
+        Progress progress,
+        ProductType productType,
+        String customerName,
+        InquiryType inquiryType,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    );
+
+    List<InquirySummaryResponseDTO> findInquiriesByCustomerWithoutPaging(
+        Long userId,
+        Progress progress,
+        ProductType productType,
+        String customerName,
+        InquiryType inquiryType,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    );
+
+    List<InquirySummaryResponseDTO> findInquiriesByManagerWithoutPaging(
         Progress progress,
         ProductType productType,
         String customerName,

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryRepositoryImpl.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryRepositoryImpl.java
@@ -85,6 +85,42 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
     }
 
     @Override
+    public List<InquirySummaryResponseDTO> findInquiriesByCustomerWithoutPaging(
+        Long userId,
+        Progress progress,
+        ProductType productType,
+        String customerName,
+        InquiryType inquiryType,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    ) {
+       return queryFactory
+            .select(Projections.constructor(InquirySummaryResponseDTO.class,
+                    inquiry.inquiryId,
+                    inquiry.salesPerson,
+                    inquiry.progress,
+                    inquiry.productType,
+                    inquiry.inquiryType,
+                    customer.customerName
+                )
+            )
+            .from(inquiry)
+            .join(inquiry.customer, customer)
+            .where(
+                inquiry.isActivated.eq(true),
+                inquiry.customer.userId.eq(userId),
+                progressEq(progress),
+                productTypeEq(productType),
+                customerNameEq(customerName),
+                inquiryTypeEq(inquiryType),
+                createdDateBetween(startDate, endDate)
+            )
+            .orderBy(getOrderSpecifier(sortBy))
+            .fetch();
+    }
+
+    @Override
     public Page<InquirySummaryResponseDTO> findInquiriesByManager(
         Pageable pageable,
         Progress progress,
@@ -130,6 +166,40 @@ public class InquiryRepositoryImpl implements InquiryRepositoryCustom {
         );
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
+
+    @Override
+    public List<InquirySummaryResponseDTO> findInquiriesByManagerWithoutPaging(
+        Progress progress,
+        ProductType productType,
+        String customerName,
+        InquiryType inquiryType,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    ) {
+        return queryFactory
+            .select(Projections.constructor(InquirySummaryResponseDTO.class,
+                    inquiry.inquiryId,
+                    inquiry.salesPerson,
+                    inquiry.progress,
+                    inquiry.productType,
+                    inquiry.inquiryType,
+                    customer.customerName
+                )
+            )
+            .from(inquiry)
+            .join(inquiry.customer, customer)
+            .where(
+                inquiry.isActivated.isTrue(),
+                progressEq(progress),
+                productTypeEq(productType),
+                customerNameEq(customerName),
+                inquiryTypeEq(inquiryType),
+                createdDateBetween(startDate, endDate)
+            )
+            .orderBy(getOrderSpecifier(sortBy))
+            .fetch();
     }
 
     private JPAQuery<Inquiry> getCountQueryForCustomer(

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -92,6 +92,38 @@ public class InquiryService {
     }
 
     @Transactional(readOnly = true)
+    public List<InquirySummaryResponseDTO> getInquiriesByCustomerWithoutPaging(
+        String token,
+        Long customerId,
+        String sortBy,
+        Progress progress,
+        ProductType productType,
+        String customerName,
+        InquiryType inquiryType,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        Long userId = signService.parseToken(token);
+
+        Customer customer = customerRepository.findById(userId)
+            .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        if(!Objects.equals(customer.getUserId(), customerId))
+            throw new CommonException(ErrorCode.USER_NOT_MATCHED);
+
+        return inquiryRepository.findInquiriesByCustomerWithoutPaging(
+            customerId,
+            progress,
+            productType,
+            customerName,
+            inquiryType,
+            startDate,
+            endDate,
+            sortBy
+        );
+    }
+
+    @Transactional(readOnly = true)
     public Page<InquirySummaryResponseDTO> getInquiriesByManager(
         String token,
         int page,
@@ -116,6 +148,36 @@ public class InquiryService {
 
         return inquiryRepository.findInquiriesByManager(
             pageable,
+            progress,
+            productType,
+            customerName,
+            inquiryType,
+            startDate,
+            endDate,
+            sortBy
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<InquirySummaryResponseDTO> getInquiriesByManagerWithoutPaging(
+        String token,
+        String sortBy,
+        Progress progress,
+        ProductType productType,
+        String customerName,
+        InquiryType inquiryType,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        Long userId = signService.parseToken(token);
+
+        Manager manager = managerRepository.findById(userId)
+            .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        if(manager.getRole() == UserRole.CUSTOMER)
+            throw new CommonException(ErrorCode.UNAUTHORIZED_USER_MANAGER);
+
+        return inquiryRepository.findInquiriesByManagerWithoutPaging(
             progress,
             productType,
             customerName,

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -54,6 +54,7 @@ public class InquiryService {
 
     private final ManagerRepository managerRepository;
 
+    // Inquiry 전체 조회(고객사)
     @Transactional(readOnly = true)
     public Page<InquirySummaryResponseDTO> getInquiriesByCustomer(
         String token,
@@ -91,6 +92,7 @@ public class InquiryService {
         );
     }
 
+    // Inquiry 전체 조회(고객사) without paging
     @Transactional(readOnly = true)
     public List<InquirySummaryResponseDTO> getInquiriesByCustomerWithoutPaging(
         String token,
@@ -123,6 +125,7 @@ public class InquiryService {
         );
     }
 
+    // Inquiry 전체 조회(담당자)
     @Transactional(readOnly = true)
     public Page<InquirySummaryResponseDTO> getInquiriesByManager(
         String token,
@@ -158,6 +161,7 @@ public class InquiryService {
         );
     }
 
+    // Inquiry 전체 조회(담당자) without paging
     @Transactional(readOnly = true)
     public List<InquirySummaryResponseDTO> getInquiriesByManagerWithoutPaging(
         String token,

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
@@ -57,7 +57,7 @@ public class QuestionController {
     }
 
     @GetMapping("/managers")
-    @Operation(summary = "Question 전체 조회(담당자)", description = "등록된 모든 Question을 조건에 맞게 페이징 없이 조회한다.")
+    @Operation(summary = "Question 조회(담당자)", description = "등록된 모든 Question을 조건에 맞게 페이징 없이 조회한다.")
     public ResponseEntity<JsonResult> getAllQuestionsByManagerWithoutPaging(
         @RequestHeader("Authorization") String token,
         @RequestParam(defaultValue = "LATEST") String sortBy,
@@ -123,7 +123,7 @@ public class QuestionController {
     }
 
     @GetMapping("/customers/{userId}")
-    @Operation(summary = "Question 전체 조회(고객사)", description = "등록된 모든 Question을 조건에 맞게 페이징 없이 조회한다.")
+    @Operation(summary = "Question 조회(고객사)", description = "등록된 모든 Question을 조건에 맞게 페이징 없이 조회한다.")
     public ResponseEntity<JsonResult> getAllQuestionsByCustomerWithoutPaging(
         @RequestHeader("Authorization") String token,
         @PathVariable Long userId,

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
@@ -2,8 +2,10 @@ package com.pobluesky.backend.domain.question.controller;
 
 import com.pobluesky.backend.domain.question.dto.request.QuestionCreateRequestDTO;
 import com.pobluesky.backend.domain.question.dto.response.QuestionResponseDTO;
+import com.pobluesky.backend.domain.question.dto.response.QuestionSummaryDTO;
 import com.pobluesky.backend.domain.question.dto.response.QuestionSummaryResponseDTO;
 import com.pobluesky.backend.domain.question.entity.QuestionStatus;
+import com.pobluesky.backend.domain.question.entity.QuestionType;
 import com.pobluesky.backend.domain.question.service.QuestionService;
 import com.pobluesky.backend.global.util.ResponseFactory;
 import com.pobluesky.backend.global.util.model.JsonResult;
@@ -29,7 +31,7 @@ public class QuestionController {
 
     private final QuestionService questionService;
 
-    @GetMapping("/managers")
+    @GetMapping("/managers/all")
     @Operation(summary = "Question 조회(담당자)", description = "등록된 모든 Question을 조건에 맞게 조회한다.")
     public ResponseEntity<JsonResult> getQuestionByManager(
         @RequestHeader("Authorization") String token,
@@ -46,7 +48,31 @@ public class QuestionController {
             size,
             sortBy,
             status,
-            startDate, endDate
+            startDate,
+            endDate
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/managers")
+    @Operation(summary = "Question 전체 조회(담당자)", description = "등록된 모든 Question을 조건에 맞게 페이징 없이 조회한다.")
+    public ResponseEntity<JsonResult> getAllQuestionsByManagerWithoutPaging(
+        @RequestHeader("Authorization") String token,
+        @RequestParam(defaultValue = "LATEST") String sortBy,
+        @RequestParam(required = false) QuestionStatus status,
+        @RequestParam(required = false) QuestionType type,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
+
+        List<QuestionSummaryDTO> response = questionService.getAllQuestionsByManagerWithoutPaging(
+            token,
+            sortBy,
+            status,
+            type,
+            startDate,
+            endDate
         );
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -69,7 +95,7 @@ public class QuestionController {
             .body(ResponseFactory.getSuccessJsonResult(response));
     }
 
-    @GetMapping("/customers/{userId}")
+    @GetMapping("/customers/{userId}/all")
     @Operation(summary = "Question 조회(고객사)", description = "등록된 모든 Question을 조건에 맞게 조회한다.")
     public ResponseEntity<JsonResult> getQuestionsByCustomer(
         @RequestHeader("Authorization") String token,
@@ -88,6 +114,31 @@ public class QuestionController {
             size,
             sortBy,
             status,
+            startDate,
+            endDate
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/customers/{userId}")
+    @Operation(summary = "Question 전체 조회(고객사)", description = "등록된 모든 Question을 조건에 맞게 페이징 없이 조회한다.")
+    public ResponseEntity<JsonResult> getAllQuestionsByCustomerWithoutPaging(
+        @RequestHeader("Authorization") String token,
+        @PathVariable Long userId,
+        @RequestParam(defaultValue = "LATEST") String sortBy,
+        @RequestParam(required = false) QuestionStatus status,
+        @RequestParam(required = false) QuestionType type,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
+
+        List<QuestionSummaryDTO> response = questionService.getAllQuestionsByCustomerWithoutPaging(
+            token,
+            userId,
+            sortBy,
+            status,
+            type,
             startDate,
             endDate
         );

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/dto/response/QuestionSummaryDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/dto/response/QuestionSummaryDTO.java
@@ -3,6 +3,7 @@ package com.pobluesky.backend.domain.question.dto.response;
 import com.pobluesky.backend.domain.question.entity.Question;
 import com.pobluesky.backend.domain.question.entity.QuestionStatus;
 
+import com.pobluesky.backend.domain.question.entity.QuestionType;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
@@ -12,6 +13,7 @@ public record QuestionSummaryDTO(
     Long questionId,
     String title,
     QuestionStatus status,
+    QuestionType type,
     String contents,
     String customerName,
     LocalDateTime questionCreatedAt,
@@ -23,6 +25,7 @@ public record QuestionSummaryDTO(
             .questionId(question.getQuestionId())
             .title(question.getTitle())
             .status(question.getStatus())
+            .type(question.getType())
             .contents(question.getContents())
             .customerName(question.getCustomer().getCustomerName())
             .questionCreatedAt(question.getCreatedDate())

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.pobluesky.backend.domain.question.repository;
 
+import com.pobluesky.backend.domain.question.dto.response.QuestionSummaryDTO;
 import com.pobluesky.backend.domain.question.dto.response.QuestionSummaryResponseDTO;
 import com.pobluesky.backend.domain.question.entity.QuestionStatus;
 
+import com.pobluesky.backend.domain.question.entity.QuestionType;
 import java.time.LocalDate;
 
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface QuestionRepositoryCustom {
@@ -19,6 +22,23 @@ public interface QuestionRepositoryCustom {
     QuestionSummaryResponseDTO findQuestionsByManager(
         Pageable pageable,
         QuestionStatus status,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    );
+
+    List<QuestionSummaryDTO> findAllQuestionsByCustomerWithoutPaging(
+        Long userId,
+        QuestionStatus status,
+        QuestionType type,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    );
+
+    List<QuestionSummaryDTO> findAllQuestionsByManagerWithoutPaging(
+        QuestionStatus status,
+        QuestionType type,
         LocalDate startDate,
         LocalDate endDate,
         String sortBy

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
@@ -129,6 +129,7 @@ public class QuestionService {
             sortBy);
     }
 
+    // 질문 전체 조회 (고객사) without paging
     @Transactional(readOnly = true)
     public List<QuestionSummaryDTO> getAllQuestionsByCustomerWithoutPaging(
         String token,


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - Inquiry 조회(페이징 제외) API 추가
     - 기존 API 명세서 사용하면 됩니다. 
        (페이징 처리가 포함된 API는 현재 모든 엔드포인트 뒤에 /all 추가된 상태: 사용 여부 결정 후 삭제 예정) 
     - 응답 구조 동일 
  - Collaboration 조회(페이징 제외) API 추가 
     - 기존 API 명세서 사용하면 됩니다. 
        (페이징 처리가 포함된 API는 현재 모든 엔드포인트 뒤에 /all 추가된 상태: 사용 여부 결정 후 삭제 예정) 
     - 응답 구조 동일 
  - Question 조회(페이징 제외) API 추가 
     - 기존 API 명세서 사용하면 됩니다. 
        (페이징 처리가 포함된 API는 현재 모든 엔드포인트 뒤에 /all 추가된 상태: 사용 여부 결정 후 삭제 예정)  
     - `Before` QuestionType에 따라 리스트 형태로 응답 리턴 -> 
         `After`  하나의 문의 리스트 response에 QuestionType를 가진 응답 리턴 
      - 정렬 조건 QuestionType 추가 -> 해당 타입별로 응답 리스트 정렬 
  
- **API 명세서 참고 (페이징 여부에 따른 Response 수정함)**
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
<br>