### PR TITLE
Be hotfix#217  pjh collaboration update status fix

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepository.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/repository/CollaborationRepository.java
@@ -16,7 +16,4 @@ public interface CollaborationRepository extends JpaRepository<Collaboration, Lo
 
     @Query("SELECT c FROM Collaboration c WHERE c.colId = :collaborationId AND c.question = :question")
     Optional<Collaboration> findByIdAndQuestion(@Param("collaborationId") Long collaborationId, @Param("question") Question question);
-
-    @Query("SELECT c FROM Collaboration c WHERE c.colRequestManager = :requestManager AND c.colResponseManager = :responseManager")
-    Optional<Collaboration> findByRequestManagerAndResponseManager(Manager requestManager, Manager responseManager);
 }

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -8,43 +8,64 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    // Global
     UNKNOWN(HttpStatus.INTERNAL_SERVER_ERROR, "G0001", "알 수 없는 오류가 발생했습니다."),
     INVALID_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "G0002", "잘못된 요청입니다."),
     EXTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G0003", "외부 서버 오류입니다."),
+    INVALID_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "G0004","권한 정보가 없는 토큰입니다."),
+
+    // User
     USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0001", "존재하지 않는 사용자입니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "U0004","이미 존재하는 이메일입니다."),
     REQ_MANAGER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0002", "존재하지 않는 요청 담당자입니다."),
     RES_MANAGER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0003", "존재하지 않는 응답 담당자입니다."),
-    INQUIRY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0001", "존재하지 않는 문의입니다."),
-    INVALID_ORDER_CONDITION(HttpStatus.INTERNAL_SERVER_ERROR, "I0002", "올바르지 않은 정렬 조건입니다."),
-    REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),
-    REVIEW_ALREADY_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "R0002", "해당 Inquiry에는 이미 제출된 검토가 존재합니다."),
-    INVALID_PRODUCT_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "P0001", "유효하지 않은 제품 유형입니다."),
-    LINE_ITEM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0001", "존재하지 않는 라인아이템입니다."),
-    QUALITY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Q0001", "존재하지 않는 품질입니다."),
-    QUALITY_REVIEW_INFO_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Q0002", "존재하지 않는 품질검토정보입니다."),
-    QUALITY_ALREADY_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "Q0003", "해당 Inquiry에는 이미 제출된 품질이 존재합니다."),
-    OFFERSHEET_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "O0001", "존재하지 않는 오퍼시트입니다."),
-    NOTIFICATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "N0001", "존재하지 않는 알림입니다."),
-    INVALID_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "G0003","권한 정보가 없는 토큰입니다."),
-    PROGRESS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "P0002", "존재하지 않는 진행단계입니다."),
-    QUESTION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Q0001", "존재하지 않는 질문입니다."),
-    QUESTION_STATUS_COMPLETED(HttpStatus.INTERNAL_SERVER_ERROR, "Q0003", "이미 답변이 완료된 질문입니다."),
-    ANSWER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "A0001", "존재하지 않는 답변입니다."),
-    COLLABORATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "C0001", "존재하지 않는 협업입니다."),
-    COLLABORATION_ALREADY_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "C0002", "이미 존재하는 협업입니다."),
-    COLLABORATION_STATUS_COMPLETED(HttpStatus.INTERNAL_SERVER_ERROR, "C0003", "이미 완료된 협업입니다."),
-    COLLABORATION_STATUS_REFUSED(HttpStatus.INTERNAL_SERVER_ERROR, "C0004", "이미 거절된 협업입니다."),
     INVALID_PASSWORD(HttpStatus.INTERNAL_SERVER_ERROR, "U0005", "비밀번호가 틀립니다."),
-    RESMANAGER_NOT_MACHED(HttpStatus.INTERNAL_SERVER_ERROR, "U0006", "해당 협업의 응답 담당자가 아닙니다."),
     USER_NOT_MATCHED(HttpStatus.INTERNAL_SERVER_ERROR, "U0007","적합한 사용자가 아닙니다."),
     UNAUTHORIZED_USER_SALES(HttpStatus.INTERNAL_SERVER_ERROR, "U0008", "판매 담당자가 아닙니다."),
     UNAUTHORIZED_USER_QUALITY(HttpStatus.INTERNAL_SERVER_ERROR, "U0009", "품질 담당자가 아닙니다."),
     UNAUTHORIZED_USER_CUSTOMER(HttpStatus.INTERNAL_SERVER_ERROR, "U0010", "고객사가 아닙니다."),
     UNAUTHORIZED_USER_MANAGER(HttpStatus.INTERNAL_SERVER_ERROR, "U0011", "담당자가 아닙니다."),
-    RECEIPT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 내역입니다.");
+
+    // Inquiry
+    INQUIRY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0001", "존재하지 않는 문의입니다."),
+    INVALID_ORDER_CONDITION(HttpStatus.INTERNAL_SERVER_ERROR, "I0002", "올바르지 않은 정렬 조건입니다."),
+    PROGRESS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0003", "존재하지 않는 진행단계입니다."),
+
+    // Review
+    REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "R0002", "해당 Inquiry에는 이미 제출된 검토가 존재합니다."),
+
+    // LineItem
+    LINE_ITEM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "L0001", "존재하지 않는 라인아이템입니다."),
+
+    // Quality
+    QUALITY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Q0001", "존재하지 않는 품질입니다."),
+    QUALITY_REVIEW_INFO_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Q0002", "존재하지 않는 품질검토정보입니다."),
+    QUALITY_ALREADY_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "Q0003", "해당 Inquiry에는 이미 제출된 품질이 존재합니다."),
+
+    // OfferSheet
+    OFFERSHEET_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "O0001", "존재하지 않는 오퍼시트입니다."),
+
+    // Notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "N0001", "존재하지 않는 알림입니다."),
+
+    // Question
+    QUESTION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "Q0001", "존재하지 않는 질문입니다."),
+    QUESTION_STATUS_COMPLETED(HttpStatus.INTERNAL_SERVER_ERROR, "Q0003", "이미 답변이 완료된 질문입니다."),
+
+    // Answer
+    ANSWER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "A0001", "존재하지 않는 답변입니다."),
+
+    // Collaboration
+    COLLABORATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "C0001", "존재하지 않는 협업입니다."),
+    COLLABORATION_STATUS_INPROGRESS(HttpStatus.INTERNAL_SERVER_ERROR, "C0002", "이미 진행중인 협업입니다."),
+    COLLABORATION_STATUS_COMPLETED(HttpStatus.INTERNAL_SERVER_ERROR, "C0003", "이미 완료된 협업입니다."),
+    COLLABORATION_STATUS_REFUSED(HttpStatus.INTERNAL_SERVER_ERROR, "C0004", "이미 거절된 협업입니다."),
+    COLLABORATION_INFO_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "C0005", "일치하지 않은 협업 정보입니다."),
+    RESMANAGER_NOT_MACHED(HttpStatus.INTERNAL_SERVER_ERROR, "C0006", "해당 협업의 응답 담당자가 아닙니다.");
 
     private HttpStatus status;
     private String code;
     private String message;
 }
+


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - 협업 수락/거절 로직 수정
    - 동일한 요청자와 응답자 사이에 여러 개의 협업이 존재할 수 있는데, 기존 로직은 단일 결과를 기대했음 
      -> 여러 협업건을 받을 수 있도록 수정
  - A(ReqManager) -> B(ResManager) 6번 questionId에 대해 협업 요청 후, B가 수락 시 해당 협업건에 대해 상태 변경(거절) 불가 
  - Error Code 도메인별로 정리 
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
<br>