### PR TITLE
Fe hotfix#254 bjy  logout cookie issue

### DIFF
--- a/frontend/src/apis/utils/authUtils.js
+++ b/frontend/src/apis/utils/authUtils.js
@@ -17,11 +17,17 @@ const signInApi = async (endpoint, credentials) => {
 
             setCookie('refreshToken', refreshToken, {
                 path: '/',
-                maxAge: 7 * 24 * 60 * 60, // 7일 동안 유효
+                maxAge: 7 * 24 * 60 * 60,
             });
 
-            setCookie('userRole', userRole);
-            setCookie('userId', userId);
+            setCookie('userRole', userRole, {
+                path: '/',
+                maxAge: 7 * 24 * 60 * 60,
+            });
+            setCookie('userId', userId, {
+                path: '/',
+                maxAge: 7 * 24 * 60 * 60,
+            });
 
             return {
                 success: true,

--- a/frontend/src/apis/utils/axiosInstance.js
+++ b/frontend/src/apis/utils/axiosInstance.js
@@ -37,7 +37,7 @@ axiosInstance.interceptors.response.use(
             try {
                 const refreshToken = getCookie('refreshToken');
                 if (!refreshToken) {
-                    removeCookie('accessToken');
+                    removeCookie('accessToken', {path: '/'});
                     return Promise.reject(error);
                 }
 
@@ -75,8 +75,12 @@ axiosInstance.interceptors.response.use(
 
                 return { ...updatedResponse, userRole: newRole };
             } catch (err) {
-                removeCookie('accessToken');
-                removeCookie('refreshToken');
+                removeCookie('accessToken', {
+                    path: '/'
+                });
+                removeCookie('refreshToken', {
+                    path: '/'
+                });
                 return Promise.reject(err);
             }
         }

--- a/frontend/src/apis/utils/cookies.js
+++ b/frontend/src/apis/utils/cookies.js
@@ -11,9 +11,5 @@ export const getCookie = (name) => {
 };
 
 export const removeCookie = (name, options = {}) => {
-  const defaultOptions = { path: '/' };
-
-  const mergedOptions = { ...defaultOptions, ...options };
-
-  return cookies.remove(name, mergedOptions);
+  return cookies.remove(name, options);
 };

--- a/frontend/src/context/auth/AuthContext.js
+++ b/frontend/src/context/auth/AuthContext.js
@@ -50,9 +50,10 @@ export const AuthProvider = ({ children }) => {
 
     // 로그아웃 함수
     const logout = () => {
-        removeCookie('accessToken');
-        removeCookie('userRole');
-        removeCookie('userId');
+        removeCookie('accessToken', { path: '/'});
+        removeCookie('refreshToken',  { path: '/'});
+        removeCookie('userRole',  { path: '/'});
+        removeCookie('userId',  { path: '/'});
 
         setRole(null);
         setToken(null);


### PR DESCRIPTION
### Part
  - [X] FE
  - [ ] BE
<br>

### Changes
  - 로그아웃 쿠키 삭제 버그 해결
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
  - [X] 여러 페이지에 접속 후, 새로고침 시 쿠키 쌓이지 않는지 확인 완료
  - [X] 여러 브라우저 창 띄우고 계정 로그인 여러 시도 후, 쿠키 겹치지 않는지 테스트 완료
<br>

### Comments
  - 관련 이슈는 Cookie가 동일 경로에만 저장이 되어야 하는데, 현재 path: /, /inq-list, /inq-form, /inq-list/${role}/13 ... 등등 여러 경로에 쿠키 속 정보(token, userId, userRole) 가 쌓이는 문제가 있었습니다.
  - 이로 인해 고객사로 로그인을 해도 담당자만 사용할 수 있는 페이지로 넘어가는 등의 문제가 종종 발생하였었습니다.
  - 찾아보니 cookie에 token, userId, userRole을 담을 때, setCookie('accessToken', {path: '/'})으로 path를 지정할 수 있는데, path를 꼭 지정해 주어야 하며, 이를 removeCookie('accessToken', {path: '/'})와 일치시켜 주어야 한다고 하네요.
  - 만약, setCookie & removeCookie 를 할 때, path를 같은 경로로 지정해 주지 않는다면, 여러 경로에서 쿠키가 쌓이고 로그아웃 시 쿠키가 완전히 삭제되지 않는 이슈가 발생한다고 해요!
  - 결국 해결했습니다...😁
<br>

### [공식문서] https://www.npmjs.com/package/js-cookie#cookie-attributes

> **IMPORTANT! When deleting a cookie and you're not relying on the [default attributes](https://www.npmjs.com/package/js-cookie#cookie-attributes), you must pass the exact same path and domain attributes that were used to set the cookie:**

<br>