### PR TITLE
Be feat#330 pjh  inquiry sep lineitem

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
@@ -4,6 +4,7 @@ import com.amazonaws.Response;
 import com.pobluesky.backend.domain.inquiry.dto.request.InquiryCreateRequestDTO;
 import com.pobluesky.backend.domain.inquiry.dto.request.InquiryUpdateRequestDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryAllocateResponseDTO;
+import com.pobluesky.backend.domain.inquiry.dto.response.InquiryFavoriteLineItemResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryFavoriteResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryProgressResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryResponseDTO;
@@ -297,6 +298,19 @@ public class InquiryController {
         inquiryService.updateFavoriteInquiryStatus(token, inquiryId);
 
         return ResponseEntity.ok(ResponseFactory.getSuccessResult());
+    }
+
+    @GetMapping("customers/inquiries/{userId}/{inquiryId}/line-items")
+    @Operation(summary = "특정 inquiryId에 해당하는 라인 아이템 조회")
+    public ResponseEntity<JsonResult> getLineItemsByInquiryId(
+        @RequestHeader("Authorization") String token,
+        @PathVariable Long userId,
+        @PathVariable Long inquiryId
+    ) {
+        InquiryFavoriteLineItemResponseDTO response =
+            inquiryService.getLineItemsByInquiryId(token, userId, inquiryId);
+
+        return ResponseEntity.ok(ResponseFactory.getSuccessJsonResult(response));
     }
 
     /* [Start] Dashboard API */

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/InquiryFavoriteLineItemResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/InquiryFavoriteLineItemResponseDTO.java
@@ -1,0 +1,19 @@
+package com.pobluesky.backend.domain.inquiry.dto.response;
+
+import com.pobluesky.backend.domain.inquiry.entity.Inquiry;
+import com.pobluesky.backend.domain.lineitem.dto.response.LineItemResponseDTO;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record InquiryFavoriteLineItemResponseDTO(
+    Long inquiryId,
+    List<LineItemResponseDTO> lineItemList
+) {
+    public static InquiryFavoriteLineItemResponseDTO of(Inquiry inquiry, List<LineItemResponseDTO> lineItems) {
+        return InquiryFavoriteLineItemResponseDTO.builder()
+            .inquiryId(inquiry.getInquiryId())
+            .lineItemList(lineItems)
+            .build();
+    }
+}


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - 특정 InquiryId에 따른 라인아이템 조회 API 구현
     - 즐겨찾기 서비스에서 특정 라인아이템 선택 후 Inquiry 등록 시 간편하게 등록하기 위함 
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
  - [X] API 명세서 참고 
<br>
