### PR TITLE
Be feat#291 pjh inquiry lineitem optimizer

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -63,6 +63,20 @@ dependencies {
 	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 
 	runtimeOnly 'org.postgresql:postgresql'
+
+	// google cloud vision
+	implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+	implementation platform('com.google.cloud:libraries-bom:26.1.4')
+	implementation 'com.google.cloud:google-cloud-bigquery'
+	implementation 'com.google.cloud:google-cloud-vision:3.3.0'
+
+	// gcp storage
+	implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.8.RELEASE'
+
+	//PDF
+	implementation 'org.apache.pdfbox:pdfbox:2.0.27'
+	implementation 'org.apache.pdfbox:pdfbox-tools:2.0.27'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
@@ -14,6 +14,7 @@ import com.pobluesky.backend.domain.inquiry.entity.InquiryType;
 import com.pobluesky.backend.domain.inquiry.entity.ProductType;
 import com.pobluesky.backend.domain.inquiry.entity.Progress;
 import com.pobluesky.backend.domain.inquiry.service.InquiryService;
+import com.pobluesky.backend.domain.inquiry.service.IntegratedOcrGptService;
 import com.pobluesky.backend.global.util.ResponseFactory;
 import com.pobluesky.backend.global.util.model.CommonResult;
 import com.pobluesky.backend.global.util.model.JsonResult;
@@ -47,6 +48,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class InquiryController {
 
     private final InquiryService inquiryService;
+    private final IntegratedOcrGptService integratedOcrGptService;
 
     @GetMapping("/customers/inquiries/{userId}")
     @Operation(summary = "Inquiry 조회(고객사)", description = "등록된 모든 Inquiry를 조건에 맞게 조회한다.")
@@ -358,6 +360,20 @@ public class InquiryController {
         @RequestHeader("Authorization") String token
     ) {
         Map<String, List<Object[]>> response = inquiryService.getInquiryCountsByProductType(token);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/customers/inquiries/{userId}/optimized")
+    @Operation(summary = "제품 유형별 라인아이템 등록 최적화")
+    public ResponseEntity<JsonResult<?>> processOcrAndChatGpt(
+        @RequestHeader("Authorization") String token,
+        @PathVariable Long userId,
+        @RequestParam("files") MultipartFile file,
+        @RequestParam("productType") ProductType productType
+    ) {
+        JsonResult<?> response =
+            integratedOcrGptService.processFileAndStructureData(token, userId, file, productType);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/request/ChatRequestMsgDto.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/request/ChatRequestMsgDto.java
@@ -1,0 +1,11 @@
+package com.pobluesky.backend.domain.inquiry.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRequestMsgDto {
+    private String role;
+    private String content;
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/ChatCompletionDto.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/ChatCompletionDto.java
@@ -1,0 +1,13 @@
+package com.pobluesky.backend.domain.inquiry.dto.response;
+
+import com.pobluesky.backend.domain.inquiry.dto.request.ChatRequestMsgDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatCompletionDto {
+    private String model;
+    private List<ChatRequestMsgDto> messages;
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/GptPromptService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/GptPromptService.java
@@ -1,0 +1,32 @@
+package com.pobluesky.backend.domain.inquiry.service;
+
+import com.pobluesky.backend.domain.inquiry.dto.response.ChatCompletionDto;
+import com.pobluesky.backend.global.config.RestTemplateConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GptPromptService {
+    private final RestTemplateConfig restTemplateConfig;
+
+    @Value("${openai.url.prompt}")
+    private String promptUrl;
+
+    public String prompt(ChatCompletionDto chatCompletionDto) {
+
+        HttpHeaders headers = restTemplateConfig.httpHeaders();
+
+        HttpEntity<ChatCompletionDto> requestEntity = new HttpEntity<>(chatCompletionDto, headers);
+        ResponseEntity<String> response = restTemplateConfig
+            .restTemplate()
+            .exchange(promptUrl, HttpMethod.POST, requestEntity, String.class);
+
+        return response.getBody();
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -556,16 +556,6 @@ public class InquiryService {
         return results;
     }
 
-    private void validateUserAndToken(String token, Long customerId) {
-        Long userId = signService.parseToken(token);
-
-        Customer customer = customerRepository.findById(userId)
-            .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
-
-        if (!Objects.equals(customer.getUserId(), customerId))
-            throw new CommonException(ErrorCode.USER_NOT_MATCHED);
-    }
-
     private List<InquiryFavoriteResponseDTO> convertToResponseDTO(List<Inquiry> inquiries) {
         if (inquiries.isEmpty()) {
             throw new CommonException(ErrorCode.INQUIRY_LIST_EMPTY);

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/IntegratedOcrGptService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/IntegratedOcrGptService.java
@@ -1,0 +1,188 @@
+package com.pobluesky.backend.domain.inquiry.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pobluesky.backend.domain.inquiry.dto.request.ChatRequestMsgDto;
+import com.pobluesky.backend.domain.inquiry.dto.response.ChatCompletionDto;
+import com.pobluesky.backend.domain.inquiry.entity.ProductType;
+import com.pobluesky.backend.global.error.CommonException;
+import com.pobluesky.backend.global.error.ErrorCode;
+import com.pobluesky.backend.global.util.ResponseFactory;
+import com.pobluesky.backend.global.util.model.JsonResult;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+@Service
+@RequiredArgsConstructor
+public class IntegratedOcrGptService {
+
+    private final OcrService ocrService;
+    private final GptPromptService gptPromptService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.model}")
+    private String openAiModel;
+
+    public JsonResult<?> processFileAndStructureData(MultipartFile file, ProductType productType) {
+        List<String> textResults = ocrService.processPdfAndDetectText(file);
+
+        Map<String, Object> structuredData = getStructuredDataFromGPT(textResults, productType);
+
+        return ResponseFactory.getSuccessJsonResult(structuredData);
+    }
+
+    private Map<String, Object> getStructuredDataFromGPT(List<String> textResults, ProductType productType) {
+        String prompt = preparePromptByProductType(textResults, productType);
+
+        List<ChatRequestMsgDto> messages = new ArrayList<>();
+        messages.add(new ChatRequestMsgDto("system", "You are a helpful assistant that converts unstructured text to structured JSON."));
+        messages.add(new ChatRequestMsgDto("user", prompt));
+
+        ChatCompletionDto chatCompletionDto = new ChatCompletionDto(openAiModel, messages);
+        String gptResponse = gptPromptService.prompt(chatCompletionDto);
+
+        return extractJsonFromChatGptResponse(gptResponse);
+    }
+
+    private String preparePromptByProductType(List<String> textResults, ProductType productType) {
+        StringBuilder promptBuilder = new StringBuilder();
+        promptBuilder.append("Convert the following text data into a structured JSON format for ").append(productType);
+
+        for (String text : textResults) {
+            promptBuilder.append(text).append("\n");
+        }
+
+        promptBuilder.append("Please structure the JSON as follows, without any additional text or formatting:\n");
+        promptBuilder.append("{\n  \"lineItemResponseDTOs\": [\n    {\n");
+
+        switch (productType) {
+            case CAR:
+                promptBuilder.append(
+                    "      \"lab\": \"[Lab Name]\",\n" +
+                        "      \"kind\": \"[Vehicle Type]\",\n" +
+                        "      \"standardOrg\": \"[Standard Organization]\",\n" +
+                        "      \"salesVehicleName\": \"[Vehicle Name]\",\n" +
+                        "      \"partName\": \"[Part Name]\",\n" +
+                        "      \"ixPlate\": \"[Plate Type]\",\n" +
+                        "      \"thickness\": \"[Thickness in mm]\",\n" +
+                        "      \"width\": \"[Width in mm]\",\n" +
+                        "      \"quantity\": [Quantity as a number],\n" +
+                        "      \"expectedDeliveryDate\": \"[Delivery Date in yyyy-MM-dd format]\",\n" +
+                        "      \"transportationDestination\": \"[Destination]\",\n" +
+                        "      \"edge\": \"[Edge Type]\",\n" +
+                        "      \"tolerance\": \"[Tolerance in ±mm format]\",\n" +
+                        "      \"annualCost\": \"[Annual Cost in $XX,XXX format]\"\n"
+                );
+                break;
+            case COLD_ROLLED:
+                promptBuilder.append(
+                    "      \"kind\": \"[COLD ROLLED Type: The type of product, such as 'CR' or 'CRC']\",\n" +
+                        "      \"inqName\": \"[Inquiry Name: The name or identifier of the product, such as 'JS_SI123']\",\n" +
+                        "      \"orderCategory\": \"[Order Category: The intended use of the product, such as 'Pipe Material', 'Automotive Parts']\",\n" +
+                        "      \"thickness\": \"[Thickness in mm: The thickness of the product, e.g., '2.5 mm']\",\n" +
+                        "      \"width\": \"[Width in mm: The width of the product, e.g., '1500 mm']\",\n" +
+                        "      \"quantity\": [Quantity as a number: The number of items, e.g., 300],\n" +
+                        "      \"expectedDeadline\": \"[Expected Deadline in yyyy-MM-dd format]\",\n" +
+                        "      \"orderEdge\": \"[Edge Type: The edge type required for the order]\",\n" +
+                        "      \"inDiameter\": \"[Inner Diameter in mm: The inner diameter of the product]\",\n" +
+                        "      \"outDiameter\": \"[Outer Diameter in mm: The outer diameter of the product]\",\n" +
+                        "      \"sleeveThickness\": \"[Sleeve Thickness in mm: The thickness of the sleeve]\",\n" +
+                        "      \"tensileStrength\": \"[Tensile Strength in MPa: The tensile strength of the material]\",\n" +
+                        "      \"elongationRatio\": \"[Elongation Ratio in %: The elongation ratio of the material]\",\n" +
+                        "      \"hardness\": \"[Hardness in HV: The hardness of the material]\"\n"
+                );
+                break;
+            case HOT_ROLLED:
+                promptBuilder.append(
+                    "      \"kind\": \"[HOT ROLLED Type]\",\n" +
+                        "      \"inqName\": \"[Inquiry Name: The name or identifier of the product, such as 'JS_SI123']\",\n" +
+                        "      \"orderCategory\": \"[Order Category: The intended use of the product]\",\n" +
+                        "      \"thickness\": \"[TThickness in mm format]\",\n" +
+                        "      \"width\": \"[Width in mm format]\",\n" +
+                        "      \"hardness\": \"[Hardness in HV format]\",\n" +
+                        "      \"flatness\": [Flatness],\n" +
+                        "      \"orderEdge\": \"[Edge Type: The edge type required for the order]\",\n" +
+                        "      \"quantity\": [Quantity as a number],\n" +
+                        "      \"yieldingPoint\": \"[Yielding Point in MPa format]\",\n" +
+                        "      \"tensileStrength\": \"[Tensile Strength in MPa format]\",\n" +
+                        "      \"elongationRatio\": \"[Elongation Ratio in % format]\",\n" +
+                        "      \"camber\": \"[Camber in mm format]\",\n" +
+                        "      \"annualCost\": \"[Annual Cost in $XX,XXX format]\"\n"
+                );
+                break;
+            case THICK_PLATE:
+                promptBuilder.append(
+                    "      \"generalDetails\": \"[Each General Details]\",\n" +
+                        "      \"orderInfo\": \"[Each Order Info]\",\n" +
+                        "      \"ladleIngredient\": \"[Ladle Ingredient]\",\n" +
+                        "      \"productIngredient\": \"[Product Ingredient]\",\n" +
+                        "      \"seal\": \"[Seal in MPa range]\",\n" +
+                        "      \"grainSizeAnalysis\": [Boolean],\n" +
+                        "      \"show\": \"[Show, e.g. '27 J @ -20°C']\",\n" +
+                        "      \"extraShow\": \"[Extra Show, e.g. '27 J @ -20°C']\",\n" +
+                        "      \"agingShow\": \"[Aging Show, e.g. '27 J @ -20°C']\",\n" +
+                        "      \"curve\": \"[Curve in MPa format]\",\n" +
+                        "      \"additionalRequests\": \"[Additional Requests]\",\n" +
+                        "      \"hardness\": \"[Hardness in HV format]\",\n" +
+                        "      \"dropWeightTest\": [Boolean],\n" +
+                        "      \"ultrasonicTransducer\": [Boolean]\n"
+                );
+                break;
+            case WIRE_ROD:
+                promptBuilder.append(
+                    "      \"kind\": \"[WIRE ROD Type]\",\n" +
+                        "      \"inqName\": \"[Inquiry Name: The name or identifier of the product, such as 'JS_SI123']\",\n" +
+                        "      \"orderCategory\": \"[Order Category: The intended use of the product]\",\n" +
+                        "      \"diameter\": \"[Diameter in mm format]\",\n" +
+                        "      \"quantity\": [Quantity as a number],\n" +
+                        "      \"expectedDeadline\": \"[Expected Deadline in yyyy-MM-dd format]\",\n" +
+                        "      \"initialQuantity\": [Initial Quantity as a number],\n" +
+                        "      \"customerProcessing\": \"[Customer Processing]\",\n" +
+                        "      \"finalUse\": \"[Final Use]\",\n" +
+                        "      \"transportationDestination\": \"[Transportation Destination]\",\n" +
+                        "      \"annualCost\": \"[Annual Cost in $XX,XXX format]\",\n" +
+                        "      \"legalRegulatoryReview\": \"[Legal Regulatory Review]\",\n" +
+                        "      \"legalRegulatoryReviewDetail\": \"[Legal Regulatory Review Detail]\",\n" +
+                        "      \"finalCustomer\": \"[Final Customer]\"\n"
+                );
+                break;
+            default:
+                throw new CommonException(ErrorCode.INQUIRY_INVALID_PRODUCTTYPE);
+        }
+        promptBuilder.append("    }\n  ]\n}\n\n");
+        promptBuilder.append("Ensure all relevant information from the input text is included in the JSON structure.");
+        promptBuilder.append("If there are multiple line items, ensure each is represented as a separate object in the lineItemResponseDTOs array.");
+        promptBuilder.append("For 'inqName', replace any spaces with an underscore (_).");
+        promptBuilder.append("Provide only the raw JSON, without any explanatory text or code formatting.");
+
+        return promptBuilder.toString();
+    }
+
+    public Map<String, Object> extractJsonFromChatGptResponse(String chatGptResponse) {
+        System.out.println("ChatGPT Response: " + chatGptResponse);
+        try {
+            JsonNode rootNode = objectMapper.readTree(chatGptResponse);
+            JsonNode contentNode = rootNode.path("choices")
+                .path(0)
+                .path("message")
+                .path("content");
+
+            if (contentNode.isMissingNode()) {
+                return Collections.emptyMap();
+            }
+            return objectMapper.readValue(contentNode.asText(), new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            throw new CommonException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/OcrService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/OcrService.java
@@ -1,0 +1,75 @@
+package com.pobluesky.backend.domain.inquiry.service;
+
+import com.google.cloud.vision.v1.*;
+import com.pobluesky.backend.global.error.CommonException;
+import com.pobluesky.backend.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OcrService {
+
+    @Value("${cloud.gcp.storage.bucket.filePath}")
+    private String bucketFilePath;
+
+    private final PdfConversionService pdfConversionService;
+
+    public List<String> processPdfAndDetectText(MultipartFile pdfFile) {
+        try {
+            String uniqueId = generateUniqueId();
+            List<String> gcsPaths = pdfConversionService.convertPdfToImages(pdfFile.getInputStream(), uniqueId);
+
+            List<String> textResults = new ArrayList<>();
+
+            for (String gcsPath : gcsPaths) {
+                String detectedText = detectTextGcs(gcsPath);
+                textResults.add(detectedText);
+            }
+
+            return textResults;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new CommonException(ErrorCode.EXTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public String detectTextGcs(String gcsPath) throws IOException {
+        List<AnnotateImageRequest> requests = new ArrayList<>();
+
+        ImageSource imgSource = ImageSource.newBuilder().setGcsImageUri(gcsPath).build();
+        Image img = Image.newBuilder().setSource(imgSource).build();
+        Feature feat = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build();
+        AnnotateImageRequest request = AnnotateImageRequest.newBuilder().addFeatures(feat).setImage(img).build();
+        requests.add(request);
+
+        try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
+            BatchAnnotateImagesResponse response = client.batchAnnotateImages(requests);
+            List<AnnotateImageResponse> responses = response.getResponsesList();
+
+            StringBuilder detectedText = new StringBuilder();
+
+            for (AnnotateImageResponse res : responses) {
+                if (res.hasError()) {
+                    System.out.format("Error: %s%n", res.getError().getMessage());
+                    throw new CommonException(ErrorCode.OCR_PROCESS_FAIL);
+                }
+
+                if (!res.getTextAnnotationsList().isEmpty()) {
+                    detectedText.append(res.getTextAnnotations(0).getDescription());
+                }
+            }
+            return detectedText.toString();
+        }
+    }
+
+    private String generateUniqueId() {
+        return java.util.UUID.randomUUID().toString();
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/PdfConversionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/PdfConversionService.java
@@ -1,0 +1,67 @@
+package com.pobluesky.backend.domain.inquiry.service;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.pobluesky.backend.global.error.CommonException;
+import com.pobluesky.backend.global.error.ErrorCode;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class PdfConversionService {
+
+    private final Storage storage;
+
+    @Value("${cloud.gcp.storage.bucket.name}")
+    private String bucketName;
+
+    public PdfConversionService() {
+        this.storage = StorageOptions.getDefaultInstance().getService();
+    }
+
+    public List<String> convertPdfToImages(InputStream is, String uniqueId) {
+        List<String> savedImgUrls = new ArrayList<>();
+
+        try (PDDocument pdfDoc = PDDocument.load(is)) {
+            PDFRenderer pdfRenderer = new PDFRenderer(pdfDoc);
+
+            for (int i = 0; i < pdfDoc.getNumberOfPages(); i++) {
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(i, 300, ImageType.RGB);
+
+                try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                    ImageIO.write(bim, "jpg", os);
+                    byte[] imageBytes = os.toByteArray();
+
+                    String blobName = uniqueId + "/page_" + (i + 1) + ".jpg";
+                    storage.create(
+                        BlobInfo.newBuilder(bucketName, blobName).build(),
+                        imageBytes
+                    );
+
+                    // Save the GCS URI
+                    String gcsPath = "gs://" + bucketName + "/" + blobName;
+                    savedImgUrls.add(gcsPath);
+                }
+            }
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.PDF_CONVERSION_FAILED);
+        }
+
+        if (savedImgUrls.isEmpty()) {
+            throw new CommonException(ErrorCode.PDF_CONVERSION_NO_IMAGES);
+        }
+
+        return savedImgUrls;
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/global/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,29 @@
+package com.pobluesky.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Value("${openai.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate;
+    }
+
+    @Bean
+    public HttpHeaders httpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     INQUIRY_UNABLE_TO_MODIFY(HttpStatus.INTERNAL_SERVER_ERROR, "I0005", "이미 접수되어 수정 불가능한 문의입니다."),
     INQUIRY_UNABLE_ALLOCATE(HttpStatus.INTERNAL_SERVER_ERROR, "I0006", "해당 문의에는 담당자를 배정할 수 없습니다."),
     INQUIRY_LIST_EMPTY(HttpStatus.NO_CONTENT, "I0007", "해당 제품 유형에 대한 문의가 없습니다."),
+    INQUIRY_INVALID_PRODUCTTYPE(HttpStatus.INTERNAL_SERVER_ERROR, "I0008", "올바르지 않은 Product Type 요청입니다."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
     PROGRESS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0003", "존재하지 않는 진행단계입니다."),
     INVALID_PROGRESS_UPDATE(HttpStatus.INTERNAL_SERVER_ERROR, "I0004", "올바르지 않은 Progress 업데이트 요청입니다."),
     INQUIRY_UNABLE_TO_MODIFY(HttpStatus.INTERNAL_SERVER_ERROR, "I0005", "이미 접수되어 수정 불가능한 문의입니다."),
-    INQUIRY_INVALID_PRODUCTTYPE(HttpStatus.INTERNAL_SERVER_ERROR, "I0006", "올바르지 않은 Product Type 요청입니다."),
+    INQUIRY_UNABLE_ALLOCATE(HttpStatus.INTERNAL_SERVER_ERROR, "I0006", "해당 문의에는 담당자를 배정할 수 없습니다."),
+    INQUIRY_LIST_EMPTY(HttpStatus.NO_CONTENT, "I0007", "해당 제품 유형에 대한 문의가 없습니다."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "G0002", "잘못된 요청입니다."),
     EXTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G0003", "외부 서버 오류입니다."),
     INVALID_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "G0004","권한 정보가 없는 토큰입니다."),
+    JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G0005","JSON 처리 중 오류가 발생했습니다."),
 
     // User
     USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0001", "존재하지 않는 사용자입니다."),
@@ -32,8 +33,7 @@ public enum ErrorCode {
     PROGRESS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0003", "존재하지 않는 진행단계입니다."),
     INVALID_PROGRESS_UPDATE(HttpStatus.INTERNAL_SERVER_ERROR, "I0004", "올바르지 않은 Progress 업데이트 요청입니다."),
     INQUIRY_UNABLE_TO_MODIFY(HttpStatus.INTERNAL_SERVER_ERROR, "I0005", "이미 접수되어 수정 불가능한 문의입니다."),
-    INQUIRY_UNABLE_ALLOCATE(HttpStatus.INTERNAL_SERVER_ERROR, "I0006", "해당 문의에는 담당자를 배정할 수 없습니다."),
-    INQUIRY_LIST_EMPTY(HttpStatus.NO_CONTENT, "I0007", "해당 제품 유형에 대한 문의가 없습니다."),
+    INQUIRY_INVALID_PRODUCTTYPE(HttpStatus.INTERNAL_SERVER_ERROR, "I0006", "올바르지 않은 Product Type 요청입니다."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),
@@ -66,10 +66,15 @@ public enum ErrorCode {
     COLLABORATION_STATUS_COMPLETED(HttpStatus.INTERNAL_SERVER_ERROR, "C0003", "이미 완료된 협업입니다."),
     COLLABORATION_STATUS_REFUSED(HttpStatus.INTERNAL_SERVER_ERROR, "C0004", "이미 거절된 협업입니다."),
     COLLABORATION_INFO_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "C0005", "일치하지 않은 협업 정보입니다."),
-    RESMANAGER_NOT_MACHED(HttpStatus.INTERNAL_SERVER_ERROR, "C0006", "해당 협업의 응답 담당자가 아닙니다.");
+    RESMANAGER_NOT_MACHED(HttpStatus.INTERNAL_SERVER_ERROR, "C0006", "해당 협업의 응답 담당자가 아닙니다."),
+
+    // AI
+    OCR_PROCESS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AI001", "텍스트 추출에 실패했습니다."),
+    UPLOAD_FAIL_TO_GOOGLE(HttpStatus.INTERNAL_SERVER_ERROR, "AI002", "구글 스토리지에 파일 업로드를 실패했습니다."),
+    PDF_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI003", "PDF를 통한 이미지 변환에 실패했습니다."),
+    PDF_CONVERSION_NO_IMAGES(HttpStatus.INTERNAL_SERVER_ERROR, "AI004", "변환된 이미지가 존재하지 않습니다.");
 
     private HttpStatus status;
     private String code;
     private String message;
 }
-


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - inquiry 내역 등록 API 구현 
  - API의 로직은 다음과 같습니다. 
    ```
    1. 파일 업로드(only PDF) 
    2. 이미지 변환(PDF to jpg) 
    3. 텍스트 추출(with OCR) 
    4. 제품 유형에 따라 응답 구조화(json format with open ai)
    5. 클라단으로 리턴 
    ```
  - 특정 단위(폭, 두께, 수량, 납기일, 강도, 연신율, 경도 등)의 경우 잘못된 단위로 고객이 올리더라도 올바른 단위를 붙여 값을 내려주도록 지정해 줬습니다. 
     e.g. 폭: 1200(input) -> 폭: 1200mm(output)
  - 해당 API 호출 시 응답 속도 테스트해 봤을 때 최대 12ms 정도 예상됩니다. 
     파일 업로드 후 화면에 뿌려주기까지 대기해야 하는 유저를 생각하면, 프론트단에서 별도의 파일 변환 안내 문구가 있으면 좋을 듯합니다. 
  - 현재 제품 유형에 따라 같인 `edge` 필드인데도 다르게 지칭하는 유형이 있어 추후 hotfix로 따로 만들어 업데이트할 예정입니다.
     (data.sql도 함께 업데이트 예정)
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
     - 어떤 파일 형식이든 최종 업로드되는 파일 형식은 PDF여야 합니다. (자세한 방법은 슬랙에 남길게요!)
<br>

### 의견 주세요
   - e.g. AI / ocr 등 도메인을 따로 만들어 구현할까 싶었지만, 해당 기능이 사용되는 도메인은 inquiry가 맞다고 생각 들어 별도의 도메인을 설계하지 않았습니다. 