### PR TITLE
Be refactor#305 pjh 문의 목록 조회 페이징 처리

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
@@ -15,8 +15,11 @@ import io.swagger.v3.oas.annotations.Operation;
 
 import java.time.LocalDate;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,30 +35,42 @@ public class QuestionController {
 
     private final QuestionService questionService;
 
-    @GetMapping("/managers")
-    @Operation(summary = "질문 조회(담당자)", description = "등록된 모든 질문을 조건에 맞게 조회한다.")
-    public ResponseEntity<JsonResult> getAllQuestionsByManagerWithoutPaging(
+    @GetMapping("/managers/all")
+    @Operation(summary = "Question 조회(담당자)", description = "등록된 모든 Question을 조건에 맞게 조회한다.")
+    public ResponseEntity<JsonResult> getQuestionByManager(
         @RequestHeader("Authorization") String token,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "15") int size,
         @RequestParam(defaultValue = "LATEST") String sortBy,
         @RequestParam(required = false) QuestionStatus status,
         @RequestParam(required = false) QuestionType type,
         @RequestParam(required = false) String title,
         @RequestParam(required = false) Long questionId,
         @RequestParam(required = false) String customerName,
+        @RequestParam(required = false) Boolean isActivated,
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
 
-        List<QuestionSummaryResponseDTO> response = questionService.getAllQuestionsByManagerWithoutPaging(
+        Page<QuestionSummaryResponseDTO> questions = questionService.getQuestionsByManager(
             token,
+            page,
+            size,
             sortBy,
             status,
             type,
             title,
             questionId,
             customerName,
+            isActivated,
             startDate,
             endDate
         );
+
+        Map<String, Object> response = new HashMap<>();
+
+        response.put("questionsInfo", questions.getContent());
+        response.put("totalElements", questions.getTotalElements());
+        response.put("totalPages", questions.getTotalPages());
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseFactory.getSuccessJsonResult(response));

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
@@ -92,7 +92,7 @@ public class QuestionController {
 
     @GetMapping("/customers/{userId}")
     @Operation(summary = "질문 조회(고객사)", description = "등록된 모든 질문을 조건에 맞게 조회한다.")
-    public ResponseEntity<JsonResult> getAllQuestionsByCustomerWithoutPaging(
+    public ResponseEntity<JsonResult> getQuestionsByCustomer(
         @RequestHeader("Authorization") String token,
         @PathVariable Long userId,
         @RequestParam(defaultValue = "0") int page,

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/controller/QuestionController.java
@@ -26,8 +26,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/questions")
@@ -35,7 +33,7 @@ public class QuestionController {
 
     private final QuestionService questionService;
 
-    @GetMapping("/managers/all")
+    @GetMapping("/managers")
     @Operation(summary = "Question 조회(담당자)", description = "등록된 모든 Question을 조건에 맞게 조회한다.")
     public ResponseEntity<JsonResult> getQuestionByManager(
         @RequestHeader("Authorization") String token,
@@ -97,6 +95,8 @@ public class QuestionController {
     public ResponseEntity<JsonResult> getAllQuestionsByCustomerWithoutPaging(
         @RequestHeader("Authorization") String token,
         @PathVariable Long userId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "15") int size,
         @RequestParam(defaultValue = "LATEST") String sortBy,
         @RequestParam(required = false) QuestionStatus status,
         @RequestParam(required = false) QuestionType type,
@@ -105,9 +105,11 @@ public class QuestionController {
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
 
-        List<QuestionSummaryResponseDTO> response = questionService.getAllQuestionsByCustomerWithoutPaging(
+        Page<QuestionSummaryResponseDTO> questions = questionService.getQuestionsByCustomer(
             token,
             userId,
+            page,
+            size,
             sortBy,
             status,
             type,
@@ -116,6 +118,12 @@ public class QuestionController {
             startDate,
             endDate
         );
+
+        Map<String, Object> response = new HashMap<>();
+
+        response.put("questionsInfo", questions.getContent());
+        response.put("totalElements", questions.getTotalElements());
+        response.put("totalPages", questions.getTotalPages());
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseFactory.getSuccessJsonResult(response));

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
@@ -7,6 +7,8 @@ import com.pobluesky.backend.domain.question.entity.QuestionType;
 import java.time.LocalDate;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface QuestionRepositoryCustom {
     List<QuestionSummaryResponseDTO> findAllQuestionsByCustomerWithoutPaging(
@@ -20,12 +22,14 @@ public interface QuestionRepositoryCustom {
         String sortBy
     );
 
-    List<QuestionSummaryResponseDTO> findAllQuestionsByManagerWithoutPaging(
+    Page<QuestionSummaryResponseDTO> findQuestionsByManager(
+        Pageable pageable,
         QuestionStatus status,
         QuestionType type,
         String title,
         Long questionId,
         String customerName,
+        Boolean isActivated,
         LocalDate startDate,
         LocalDate endDate,
         String sortBy

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryCustom.java
@@ -6,22 +6,10 @@ import com.pobluesky.backend.domain.question.entity.QuestionStatus;
 import com.pobluesky.backend.domain.question.entity.QuestionType;
 import java.time.LocalDate;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface QuestionRepositoryCustom {
-    List<QuestionSummaryResponseDTO> findAllQuestionsByCustomerWithoutPaging(
-        Long userId,
-        QuestionStatus status,
-        QuestionType type,
-        String title,
-        Long questionId,
-        LocalDate startDate,
-        LocalDate endDate,
-        String sortBy
-    );
-
     Page<QuestionSummaryResponseDTO> findQuestionsByManager(
         Pageable pageable,
         QuestionStatus status,
@@ -30,6 +18,18 @@ public interface QuestionRepositoryCustom {
         Long questionId,
         String customerName,
         Boolean isActivated,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    );
+
+    Page<QuestionSummaryResponseDTO> findQuestionsByCustomer(
+        Pageable pageable,
+        Long userId,
+        QuestionStatus status,
+        QuestionType type,
+        String title,
+        Long questionId,
         LocalDate startDate,
         LocalDate endDate,
         String sortBy

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryImpl.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.pobluesky.backend.domain.question.entity.QQuestion.question;
 import static com.pobluesky.backend.domain.user.entity.QCustomer.customer;
 
 import com.pobluesky.backend.domain.question.dto.response.QuestionSummaryResponseDTO;
+import com.pobluesky.backend.domain.question.entity.Question;
 import com.pobluesky.backend.domain.question.entity.QuestionStatus;
 import com.pobluesky.backend.domain.question.entity.QuestionType;
 
@@ -15,6 +16,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.time.LocalDate;
@@ -22,6 +24,9 @@ import java.time.LocalDate;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
 
@@ -68,18 +73,21 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
             .fetch();
     }
 
+
     @Override
-    public List<QuestionSummaryResponseDTO> findAllQuestionsByManagerWithoutPaging(
+    public Page<QuestionSummaryResponseDTO> findQuestionsByManager(
+        Pageable pageable,
         QuestionStatus status,
         QuestionType type,
         String title,
         Long questionId,
         String customerName,
+        Boolean isActivated,
         LocalDate startDate,
         LocalDate endDate,
         String sortBy
     ) {
-        return queryFactory
+        List<QuestionSummaryResponseDTO> content = queryFactory
             .select(Projections.constructor(QuestionSummaryResponseDTO.class,
                 question.questionId,
                 question.title,
@@ -100,10 +108,41 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
                 titleContains(title),
                 questionIdEq(questionId),
                 customerNameContains(customerName),
+                isActivatedEq(isActivated),
                 createdDateBetween(startDate, endDate)
             )
             .orderBy(getOrderSpecifier(sortBy))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
             .fetch();
+
+        JPAQuery<Question> countQuery = getCountQueryForManager(
+            status, type, title, questionId, customerName, isActivated, startDate, endDate);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
+
+    private JPAQuery<Question> getCountQueryForManager(
+        QuestionStatus status,
+        QuestionType type,
+        String title,
+        Long questionId,
+        String customerName,
+        Boolean isActivated,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        return queryFactory
+            .selectFrom(question)
+            .where(
+                statusEq(status),
+                typeEq(type),
+                titleContains(title),
+                questionIdEq(questionId),
+                customerNameContains(customerName),
+                isActivatedEq(isActivated),
+                createdDateBetween(startDate, endDate)
+            );
     }
 
     private OrderSpecifier<?>[] getOrderSpecifier(String sortBy) {
@@ -148,6 +187,10 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
         return StringUtils.hasText(customerName) ? customer.customerName.contains(customerName) : null;
     }
 
+    private BooleanExpression isActivatedEq(Boolean isActivated) {
+        return isActivated != null ? question.isActivated.eq(isActivated) : null;
+    }
+
     private BooleanExpression createdDateBetween(LocalDate startDate, LocalDate endDate) {
         if (startDate == null && endDate == null) {
             return null;
@@ -155,7 +198,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
 
         DateTemplate<LocalDate> dateTemplate = Expressions.dateTemplate(
             LocalDate.class,
-            "CAST({0} AS DATE)",
+            "DATE({0})",
             question.createdDate
         );
 

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryImpl.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/repository/QuestionRepositoryImpl.java
@@ -36,54 +36,6 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<QuestionSummaryResponseDTO> findQuestionsByCustomer(
-        Pageable pageable,
-        Long userId,
-        QuestionStatus status,
-        QuestionType type,
-        String title,
-        Long questionId,
-        LocalDate startDate,
-        LocalDate endDate,
-        String sortBy
-    ) {
-        List<QuestionSummaryResponseDTO> content = queryFactory
-            .select(Projections.constructor(QuestionSummaryResponseDTO.class,
-                question.questionId,
-                question.title,
-                question.status,
-                question.type,
-                question.contents,
-                customer.customerName,
-                question.createdDate.as("questionCreatedAt"),
-                answer.createdDate.as("answerCreatedAt"),
-                question.isActivated
-            ))
-            .from(question)
-            .leftJoin(question.answer, answer)
-            .leftJoin(question.customer, customer)
-            .where(
-                question.customer.userId.eq(userId),
-                statusEq(status),
-                typeEq(type),
-                titleContains(title),
-                questionIdEq(questionId),
-                isActivatedEq(true),
-                createdDateBetween(startDate, endDate)
-            )
-            .orderBy(getOrderSpecifier(sortBy))
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
-
-        JPAQuery<Question> countQuery = getCountQueryForCustomer(
-            userId, status, type, title, questionId, startDate, endDate);
-
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
-    }
-
-
-    @Override
     public Page<QuestionSummaryResponseDTO> findQuestionsByManager(
         Pageable pageable,
         QuestionStatus status,
@@ -127,6 +79,53 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
 
         JPAQuery<Question> countQuery = getCountQueryForManager(
             status, type, title, questionId, customerName, isActivated, startDate, endDate);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
+
+    @Override
+    public Page<QuestionSummaryResponseDTO> findQuestionsByCustomer(
+        Pageable pageable,
+        Long userId,
+        QuestionStatus status,
+        QuestionType type,
+        String title,
+        Long questionId,
+        LocalDate startDate,
+        LocalDate endDate,
+        String sortBy
+    ) {
+        List<QuestionSummaryResponseDTO> content = queryFactory
+            .select(Projections.constructor(QuestionSummaryResponseDTO.class,
+                question.questionId,
+                question.title,
+                question.status,
+                question.type,
+                question.contents,
+                customer.customerName,
+                question.createdDate.as("questionCreatedAt"),
+                answer.createdDate.as("answerCreatedAt"),
+                question.isActivated
+            ))
+            .from(question)
+            .leftJoin(question.answer, answer)
+            .leftJoin(question.customer, customer)
+            .where(
+                question.customer.userId.eq(userId),
+                statusEq(status),
+                typeEq(type),
+                titleContains(title),
+                questionIdEq(questionId),
+                isActivatedEq(true),
+                createdDateBetween(startDate, endDate)
+            )
+            .orderBy(getOrderSpecifier(sortBy))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Question> countQuery = getCountQueryForCustomer(
+            userId, status, type, title, questionId, startDate, endDate);
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
     }

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
@@ -87,11 +87,13 @@ public class QuestionService {
             sortBy);
     }
 
-    // 질문 전체 조회 (고객사) without paging
+    // 질문 전체 조회 (고객사)
     @Transactional(readOnly = true)
-    public List<QuestionSummaryResponseDTO> getAllQuestionsByCustomerWithoutPaging(
+    public Page<QuestionSummaryResponseDTO> getQuestionsByCustomer(
         String token,
         Long customerId,
+        int page,
+        int size,
         String sortBy,
         QuestionStatus status,
         QuestionType type,
@@ -109,7 +111,10 @@ public class QuestionService {
             throw new CommonException(ErrorCode.USER_NOT_MATCHED);
         }
 
-        return questionRepository.findAllQuestionsByCustomerWithoutPaging(
+        Pageable pageable = PageRequest.of(page, size);
+
+        return questionRepository.findQuestionsByCustomer(
+            pageable,
             customerId,
             status,
             type,

--- a/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/question/service/QuestionService.java
@@ -26,6 +26,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -48,16 +51,19 @@ public class QuestionService {
 
     private final FileService fileService;
 
-    // 질문 전체 조회 (담당자) without paging
+    // 질문 전체 조회 (담당자)
     @Transactional(readOnly = true)
-    public List<QuestionSummaryResponseDTO> getAllQuestionsByManagerWithoutPaging(
+    public Page<QuestionSummaryResponseDTO> getQuestionsByManager(
         String token,
+        int page,
+        int size,
         String sortBy,
         QuestionStatus status,
         QuestionType type,
         String title,
         Long questionId,
         String customerName,
+        Boolean isActivated,
         LocalDate startDate,
         LocalDate endDate) {
 
@@ -66,12 +72,16 @@ public class QuestionService {
         managerRepository.findById(userId)
             .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        return questionRepository.findAllQuestionsByManagerWithoutPaging(
+        Pageable pageable = PageRequest.of(page, size);
+
+        return questionRepository.findQuestionsByManager(
+            pageable,
             status,
             type,
             title,
             questionId,
             customerName,
+            isActivated,
             startDate,
             endDate,
             sortBy);


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - 문의 목록 조회(고객사/담당자) 페이징 API 추가
  - isActivated 조건 추가
     - 고객사의 경우 true인 것만 조회 가능 
     - 담당자의 경우 RequestPram을 통해 isActivated 상태에 따라 문의 조회 가능  
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
  - [X] API 명세서 업데이트 확인 필요 
<br>
