### PR TITLE
Be feat#306 pjh 협업 게시판 수정 기능

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
@@ -1,6 +1,7 @@
 package com.pobluesky.backend.domain.collaboration.controller;
 
 import com.pobluesky.backend.domain.collaboration.dto.request.CollaborationCreateRequestDTO;
+import com.pobluesky.backend.domain.collaboration.dto.request.CollaborationModifyRequestDTO;
 import com.pobluesky.backend.domain.collaboration.dto.request.CollaborationUpdateRequestDTO;
 import com.pobluesky.backend.domain.collaboration.dto.response.CollaborationDetailResponseDTO;
 import com.pobluesky.backend.domain.collaboration.dto.response.CollaborationResponseDTO;
@@ -135,5 +136,23 @@ public class CollaborationController {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @PutMapping("/{collaborationId}/modify")
+    public ResponseEntity<JsonResult> modifyCollaboration(
+        @RequestHeader("Authorization") String token,
+        @PathVariable Long collaborationId,
+        @RequestPart(value = "files", required = false) MultipartFile file,
+        @RequestPart("collaboration") CollaborationModifyRequestDTO requestDTO
+    ) {
+        CollaborationDetailResponseDTO updatedCollaboration = collaborationService.modifyCollaboration(
+            token,
+            collaborationId,
+            file,
+            requestDTO
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ResponseFactory.getSuccessJsonResult(updatedCollaboration));
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/controller/CollaborationController.java
@@ -138,6 +138,10 @@ public class CollaborationController {
             .body(ResponseFactory.getSuccessJsonResult(response));
     }
 
+    @Operation(
+        summary = "collaborationId 별 협업 수락/거절",
+        description = "담당자별 협업 요청건에 대한 수락/거절 상태 수정"
+    )
     @PutMapping("/{collaborationId}/modify")
     public ResponseEntity<JsonResult> modifyCollaboration(
         @RequestHeader("Authorization") String token,
@@ -145,7 +149,7 @@ public class CollaborationController {
         @RequestPart(value = "files", required = false) MultipartFile file,
         @RequestPart("collaboration") CollaborationModifyRequestDTO requestDTO
     ) {
-        CollaborationDetailResponseDTO updatedCollaboration = collaborationService.modifyCollaboration(
+        CollaborationDetailResponseDTO response = collaborationService.modifyCollaboration(
             token,
             collaborationId,
             file,
@@ -153,6 +157,6 @@ public class CollaborationController {
         );
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ResponseFactory.getSuccessJsonResult(updatedCollaboration));
+            .body(ResponseFactory.getSuccessJsonResult(response));
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/dto/request/CollaborationModifyRequestDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/dto/request/CollaborationModifyRequestDTO.java
@@ -1,0 +1,10 @@
+package com.pobluesky.backend.domain.collaboration.dto.request;
+
+public record CollaborationModifyRequestDTO(
+    Long colReqId,
+    Long colResId,
+    String colContents,
+    Boolean isAccepted,
+    String colReply
+) {
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/collaboration/entity/Collaboration.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/collaboration/entity/Collaboration.java
@@ -100,4 +100,22 @@ public class Collaboration extends BaseEntity {
         this.fileName = fileName;
         this.filePath = filePath;
     }
+
+    public void modifyCollaborationContents(String newContents) {
+        this.colContents = newContents;
+    }
+
+    public void modifyColReply(String newReply) {
+        this.colReply = newReply;
+    }
+
+    public void updateCollaborationStatus(Boolean isAccepted) {
+        if (isAccepted != null) {
+            if (isAccepted) {
+                this.colStatus = ColStatus.INPROGRESS;
+            } else {
+                this.colStatus = ColStatus.REFUSE;
+            }
+        }
+    }
 }

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -74,6 +74,7 @@ public enum ErrorCode {
     COLLABORATION_STATUS_REFUSED(HttpStatus.INTERNAL_SERVER_ERROR, "C0004", "이미 거절된 협업입니다."),
     COLLABORATION_INFO_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "C0005", "일치하지 않은 협업 정보입니다."),
     RESMANAGER_NOT_MACHED(HttpStatus.INTERNAL_SERVER_ERROR, "C0006", "해당 협업의 응답 담당자가 아닙니다."),
+    REQMANAGER_NOT_MACHED(HttpStatus.INTERNAL_SERVER_ERROR, "C0007", "해당 협업의 요청 담당자가 아닙니다."),
 
     // AI
     OCR_PROCESS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AI001", "텍스트 추출에 실패했습니다."),


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - 협업 게시판 상태 수정 API 구현
  - 협업 진행 프로세스: 문의 생성 -> 협업 요청 -> 협업 수락/거절 -> **_협업 상태 수정(현재 올린 PR내 API 사용)_** -> 협업 완료
  - 협업 상태 수정 프로세스 
     - colStatus == READY, reqManager는 colContents & files 수정 가능
     - colStatus == INPROGRESS, resManager는 수락한 협업건에 대해 내용과 함께 수락 -> 거절 상태 업데이트 가능
     - colStatus == REFUASE, resManager는 거절한 협업건에 대해 내용과 함께 거절 -> 수락 상태 업데이트 가능
     - colStatus == COMPLETE, 모든 상태 변경 불가능 
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
      - 여러 케이스 테스트해봤는데, 안되는 게 있다면 알려주세요 
  - [X] API 명세서 업데이트 참고 
<br>
