### PR TITLE
Be feat#384 pjh inquiry manager allocation

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
@@ -253,16 +253,28 @@ public class InquiryController {
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/managers/inquiries/{inquiryId}/allocate")
-    @Operation(summary = "담당자 Inquiry 할당")
-    public ResponseEntity<InquiryAllocateResponseDTO> allocateManager(
+    @PutMapping("/managers/inquiries/{inquiryId}/allocate/{qualityManagerId}")
+    @Operation(summary = "Quality Manager Inquiry 배정", description = "품질+견적 유형에 대한 Inquiry 품질 담당자를 판매 담당자가 배정한다.")
+    public ResponseEntity <InquiryAllocateResponseDTO> allocateQualityManager(
         @RequestHeader("Authorization") String token,
-        @PathVariable Long inquiryId
+        @PathVariable Long inquiryId,
+        @PathVariable Long qualityManagerId
     ) {
-        InquiryAllocateResponseDTO response = inquiryService.allocateManager(token, inquiryId);
+        InquiryAllocateResponseDTO response = inquiryService.allocateQualityManager(token, inquiryId, qualityManagerId);
 
         return ResponseEntity.ok(response);
     }
+
+//    @PutMapping("/managers/inquiries/{inquiryId}/allocate")
+//    @Operation(summary = "담당자 Inquiry 할당")
+//    public ResponseEntity<InquiryAllocateResponseDTO> allocateManager(
+//        @RequestHeader("Authorization") String token,
+//        @PathVariable Long inquiryId
+//    ) {
+//        InquiryAllocateResponseDTO response = inquiryService.allocateManager(token, inquiryId);
+//
+//        return ResponseEntity.ok(response);
+//    }
 
     @GetMapping("customers/inquiries/{userId}/{productType}/all")
     @Operation(summary = "제품 유형에 따른 고객의 전체 Inquiry 목록 조회")

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/request/InquiryCreateRequestDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/request/InquiryCreateRequestDTO.java
@@ -10,6 +10,7 @@ import com.pobluesky.backend.domain.inquiry.entity.Progress;
 import com.pobluesky.backend.domain.user.entity.Manager;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public record InquiryCreateRequestDTO(
     Country country,
@@ -21,10 +22,10 @@ public record InquiryCreateRequestDTO(
     String customerRequestDate,
     String additionalRequests,
     String responseDeadline,
-    Long salesManagerId,
+    Optional<Long> salesManagerId,
     List<Map<String, Object>> lineItemRequestDTOs
 ) {
-    public Inquiry toInquiryEntity(String fileName, String filePath, Manager salesManager) {
+    public Inquiry toInquiryEntity(String fileName, String filePath, Optional<Manager> salesManager) {
 
         return Inquiry.builder()
             .country(country)
@@ -39,7 +40,7 @@ public record InquiryCreateRequestDTO(
             .fileName(fileName)
             .filePath(filePath)
             .responseDeadline(responseDeadline)
-            .salesManager(salesManager)
+            .salesManager(salesManager.orElse(null))
             .build();
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/request/InquiryCreateRequestDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/request/InquiryCreateRequestDTO.java
@@ -7,6 +7,7 @@ import com.pobluesky.backend.domain.inquiry.entity.InquiryType;
 import com.pobluesky.backend.domain.inquiry.entity.ProductType;
 import com.pobluesky.backend.domain.inquiry.entity.Progress;
 
+import com.pobluesky.backend.domain.user.entity.Manager;
 import java.util.List;
 import java.util.Map;
 
@@ -20,9 +21,10 @@ public record InquiryCreateRequestDTO(
     String customerRequestDate,
     String additionalRequests,
     String responseDeadline,
+    Long salesManagerId,
     List<Map<String, Object>> lineItemRequestDTOs
 ) {
-    public Inquiry toInquiryEntity(String fileName, String filePath) {
+    public Inquiry toInquiryEntity(String fileName, String filePath, Manager salesManager) {
 
         return Inquiry.builder()
             .country(country)
@@ -37,6 +39,7 @@ public record InquiryCreateRequestDTO(
             .fileName(fileName)
             .filePath(filePath)
             .responseDeadline(responseDeadline)
+            .salesManager(salesManager)
             .build();
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/entity/Inquiry.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/entity/Inquiry.java
@@ -83,6 +83,7 @@ public class Inquiry extends BaseEntity {
     @Builder
     private Inquiry(
         Customer customer,
+        Manager salesManager,
         Country country,
         String corporate,
         String  salesPerson,
@@ -96,7 +97,7 @@ public class Inquiry extends BaseEntity {
         String filePath,
         String responseDeadline
     ){
-        this.salesManager = null;
+        this.salesManager = salesManager;
         this.qualityManager = null;
         this.customer = customer;
         this.country = country;

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -187,7 +187,14 @@ public class InquiryService {
             filePath = fileInfo.getStoredFilePath();
         }
 
-        Inquiry inquiry = dto.toInquiryEntity(fileName, filePath);
+        Manager salesManager = managerRepository.findById(dto.salesManagerId())
+            .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        if (salesManager.getRole() != UserRole.SALES) {
+            throw new CommonException(ErrorCode.UNAUTHORIZED_USER_SALES);
+        }
+
+        Inquiry inquiry = dto.toInquiryEntity(fileName, filePath, salesManager);
         inquiry.setCustomer(customer);
 
         Inquiry savedInquiry = inquiryRepository.save(inquiry);

--- a/backend/src/main/java/com/pobluesky/backend/domain/user/controller/ManagerController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/user/controller/ManagerController.java
@@ -5,6 +5,7 @@ import com.pobluesky.backend.domain.user.dto.request.ManagerCreateRequestDTO;
 import com.pobluesky.backend.domain.user.dto.request.ManagerUpdateRequestDTO;
 import com.pobluesky.backend.domain.user.dto.response.CustomerResponseDTO;
 import com.pobluesky.backend.domain.user.dto.response.ManagerResponseDTO;
+import com.pobluesky.backend.domain.user.dto.response.ManagerSummaryResponseDTO;
 import com.pobluesky.backend.domain.user.entity.Customer;
 import com.pobluesky.backend.domain.user.entity.Manager;
 import com.pobluesky.backend.domain.user.service.ManagerService;
@@ -49,6 +50,24 @@ public class ManagerController {
     public ResponseEntity<JsonResult> getManagers() {
         List<ManagerResponseDTO> response = managerService.getManagers();
         
+        return ResponseEntity.status(HttpStatus.OK)
+            . body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/sales")
+    @Operation(summary = "판매 담당자 조회")
+    public ResponseEntity<JsonResult> getSaleManagers() {
+        List<ManagerSummaryResponseDTO> response = managerService.getSaleManagers();
+
+        return ResponseEntity.status(HttpStatus.OK)
+            . body(ResponseFactory.getSuccessJsonResult(response));
+    }
+
+    @GetMapping("/quality")
+    @Operation(summary = "품질 담당자 조회")
+    public ResponseEntity<JsonResult> getQualityManagers() {
+        List<ManagerSummaryResponseDTO> response = managerService.getQualityManagers();
+
         return ResponseEntity.status(HttpStatus.OK)
             . body(ResponseFactory.getSuccessJsonResult(response));
     }

--- a/backend/src/main/java/com/pobluesky/backend/domain/user/dto/response/ManagerSummaryResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/user/dto/response/ManagerSummaryResponseDTO.java
@@ -11,8 +11,8 @@ public record ManagerSummaryResponseDTO(
     Long userId,
     String name,
     String empNo,
+    String email,
     Department department
-
 ) {
 
     public static ManagerSummaryResponseDTO from(Manager manager) {
@@ -22,6 +22,7 @@ public record ManagerSummaryResponseDTO(
                 .userId(manager.getUserId())
                 .name(manager.getName())
                 .empNo(manager.getEmpNo())
+                .empNo(manager.getEmail())
                 .department(manager.getDepartment())
                 .build();
         }

--- a/backend/src/main/java/com/pobluesky/backend/domain/user/dto/response/ManagerSummaryResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/user/dto/response/ManagerSummaryResponseDTO.java
@@ -22,7 +22,7 @@ public record ManagerSummaryResponseDTO(
                 .userId(manager.getUserId())
                 .name(manager.getName())
                 .empNo(manager.getEmpNo())
-                .empNo(manager.getEmail())
+                .email(manager.getEmail())
                 .department(manager.getDepartment())
                 .build();
         }

--- a/backend/src/main/java/com/pobluesky/backend/domain/user/dto/response/ManagerSummaryResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/user/dto/response/ManagerSummaryResponseDTO.java
@@ -1,13 +1,18 @@
 package com.pobluesky.backend.domain.user.dto.response;
 
+import com.pobluesky.backend.domain.user.entity.Department;
 import com.pobluesky.backend.domain.user.entity.Manager;
 
+import com.pobluesky.backend.domain.user.entity.UserRole;
 import lombok.Builder;
 
 @Builder
 public record ManagerSummaryResponseDTO(
     Long userId,
-    String name
+    String name,
+    String empNo,
+    Department department
+
 ) {
 
     public static ManagerSummaryResponseDTO from(Manager manager) {
@@ -16,6 +21,8 @@ public record ManagerSummaryResponseDTO(
             return ManagerSummaryResponseDTO.builder()
                 .userId(manager.getUserId())
                 .name(manager.getName())
+                .empNo(manager.getEmpNo())
+                .department(manager.getDepartment())
                 .build();
         }
     }

--- a/backend/src/main/java/com/pobluesky/backend/domain/user/repository/ManagerRepository.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/user/repository/ManagerRepository.java
@@ -2,6 +2,8 @@ package com.pobluesky.backend.domain.user.repository;
 
 import com.pobluesky.backend.domain.user.entity.Manager;
 
+import com.pobluesky.backend.domain.user.entity.UserRole;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +13,6 @@ public interface ManagerRepository extends JpaRepository<Manager, Long> {
     Optional<Manager> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    List<Manager> findByRole(UserRole role);
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/user/service/ManagerService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/user/service/ManagerService.java
@@ -3,8 +3,10 @@ package com.pobluesky.backend.domain.user.service;
 import com.pobluesky.backend.domain.user.dto.request.ManagerCreateRequestDTO;
 import com.pobluesky.backend.domain.user.dto.request.ManagerUpdateRequestDTO;
 import com.pobluesky.backend.domain.user.dto.response.ManagerResponseDTO;
+import com.pobluesky.backend.domain.user.dto.response.ManagerSummaryResponseDTO;
 import com.pobluesky.backend.domain.user.dto.response.MobileManagerResponseDTO;
 import com.pobluesky.backend.domain.user.entity.Manager;
+import com.pobluesky.backend.domain.user.entity.UserRole;
 import com.pobluesky.backend.domain.user.repository.ManagerRepository;
 import com.pobluesky.backend.global.error.CommonException;
 import com.pobluesky.backend.global.error.ErrorCode;
@@ -49,6 +51,24 @@ public class ManagerService {
 
         return managers.stream()
             .map(ManagerResponseDTO::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ManagerSummaryResponseDTO> getSaleManagers() {
+        List<Manager> managers = managerRepository.findByRole(UserRole.SALES);
+
+        return managers.stream()
+            .map(ManagerSummaryResponseDTO::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ManagerSummaryResponseDTO> getQualityManagers() {
+        List<Manager> managers = managerRepository.findByRole(UserRole.QUALITY);
+
+        return managers.stream()
+            .map(ManagerSummaryResponseDTO::from)
             .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     UNAUTHORIZED_USER_QUALITY(HttpStatus.INTERNAL_SERVER_ERROR, "U0009", "품질 담당자가 아닙니다."),
     UNAUTHORIZED_USER_CUSTOMER(HttpStatus.INTERNAL_SERVER_ERROR, "U0010", "고객사가 아닙니다."),
     UNAUTHORIZED_USER_MANAGER(HttpStatus.INTERNAL_SERVER_ERROR, "U0011", "담당자가 아닙니다."),
+    SALES_MANAGER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0012", "존재하지 않는 품질 담당자입니다."),
 
     // Inquiry
     INQUIRY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0001", "존재하지 않는 문의입니다."),
@@ -37,7 +38,7 @@ public enum ErrorCode {
     INQUIRY_LIST_EMPTY(HttpStatus.NO_CONTENT, "I0007", "해당 제품 유형에 대한 문의가 없습니다."),
     INQUIRY_INVALID_PRODUCTTYPE(HttpStatus.INTERNAL_SERVER_ERROR, "I0008", "올바르지 않은 Product Type 요청입니다."),
     INQUIRY_NOT_MATCHED(HttpStatus.INTERNAL_SERVER_ERROR, "I0009", "해당 사용자가 작성한 Inquiry가 아닙니다."),
-
+    DEPARTMENT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0010", "존재하지 않는 부서입니다."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     UNAUTHORIZED_USER_QUALITY(HttpStatus.INTERNAL_SERVER_ERROR, "U0009", "품질 담당자가 아닙니다."),
     UNAUTHORIZED_USER_CUSTOMER(HttpStatus.INTERNAL_SERVER_ERROR, "U0010", "고객사가 아닙니다."),
     UNAUTHORIZED_USER_MANAGER(HttpStatus.INTERNAL_SERVER_ERROR, "U0011", "담당자가 아닙니다."),
-    SALES_MANAGER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0012", "존재하지 않는 품질 담당자입니다."),
+    SALES_MANAGER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0012", "존재하지 않는 판매 담당자입니다."),
+    QUALITY_MANAGER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "U0013", "존재하지 않는 품질 담당자입니다."),
 
     // Inquiry
     INQUIRY_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "I0001", "존재하지 않는 문의입니다."),

--- a/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/pobluesky/backend/global/error/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     INQUIRY_INVALID_PRODUCTTYPE(HttpStatus.INTERNAL_SERVER_ERROR, "I0008", "올바르지 않은 Product Type 요청입니다."),
     INQUIRY_NOT_MATCHED(HttpStatus.INTERNAL_SERVER_ERROR, "I0009", "해당 사용자가 작성한 Inquiry가 아닙니다."),
 
+
     // Review
     REVIEW_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "R0001", "존재하지 않는 검토입니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "R0002", "해당 Inquiry에는 이미 제출된 검토가 존재합니다."),


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - inquiry 담당자 배정 API 구현
    - `판매 담당자` 배정되는 방식
        1. 고객이 Inquiry등록 시 직접 자신의 inquiry를 담당할 판매 담당자 직접 배정 
        2. 고객이 직접 배정하지 않는 경우, 자체적으로 `구현한 배정 룰`에 의한 판매 담당자 배정
     - `품질 담당자` 배정되는 방식
       1. progress가 `FIRST_REVIEW_COMPLETED(1차검토완료)`인 경우 판매 -> 품질 담당자 직접 배정
       
     - `판매 담당자 배정 룰`
        1. inquiry 할당량 비교 -> 최소 할당량 가진 매니저 반환 
        2. 최소 할당량 같은 경우, 부서 그룹핑 후 해당 그룹 내 매니저 랜덤 배정  
       
- 판매 담당자 / 품질 담당자 조회 API 구현 
- 기존 담당자 할당 API 삭제 예정(로직 변경에 의한 미사용) 
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
  - [X] API 명세서 업데이트 확인 필요 
<br>

### 확인 필요
기존 id, name만 사용하던 `ManagerSummaryResponseDTO`에  `empNo`, `email`, `department`가 추가되었습니다.
기존 코드 내 해당 DTO를 사용하던 곳에선 별다른 문제가 없을 것 같지만, 혹시 응답 구조가  변경되면 안 되는 곳이 있다면 알려주세요!  