### PR TITLE
Be feat#444 pjh inquiry log api

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/chat/service/ExcelConversionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/chat/service/ExcelConversionService.java
@@ -10,7 +10,7 @@ import java.awt.Font;
 import java.io.ByteArrayOutputStream;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-import lombok.RequiredArgsConstructor;
+
 import org.apache.poi.ss.usermodel.*;
 
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -24,7 +24,6 @@ import java.awt.image.BufferedImage;
 import java.io.InputStream;
 
 @Service
-@RequiredArgsConstructor
 public class ExcelConversionService {
 
     private final Storage storage;

--- a/backend/src/main/java/com/pobluesky/backend/domain/chat/service/PdfConversionService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/chat/service/PdfConversionService.java
@@ -5,7 +5,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.pobluesky.backend.global.error.CommonException;
 import com.pobluesky.backend.global.error.ErrorCode;
-import lombok.RequiredArgsConstructor;
+
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class PdfConversionService {
 
     private final Storage storage;

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
@@ -265,17 +265,6 @@ public class InquiryController {
         return ResponseEntity.ok(response);
     }
 
-//    @PutMapping("/managers/inquiries/{inquiryId}/allocate")
-//    @Operation(summary = "담당자 Inquiry 할당")
-//    public ResponseEntity<InquiryAllocateResponseDTO> allocateManager(
-//        @RequestHeader("Authorization") String token,
-//        @PathVariable Long inquiryId
-//    ) {
-//        InquiryAllocateResponseDTO response = inquiryService.allocateManager(token, inquiryId);
-//
-//        return ResponseEntity.ok(response);
-//    }
-
     @GetMapping("customers/inquiries/{userId}/{productType}/all")
     @Operation(summary = "제품 유형에 따른 고객의 전체 Inquiry 목록 조회")
     public ResponseEntity<JsonResult> getAllInquiriesByProductType(

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/controller/InquiryController.java
@@ -5,6 +5,7 @@ import com.pobluesky.backend.domain.inquiry.dto.request.InquiryUpdateRequestDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryAllocateResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryFavoriteLineItemResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryFavoriteResponseDTO;
+import com.pobluesky.backend.domain.inquiry.dto.response.InquiryLogResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryProgressResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquirySummaryResponseDTO;
@@ -326,6 +327,20 @@ public class InquiryController {
         return ResponseEntity.ok(ResponseFactory.getSuccessJsonResult(response));
     }
 
+    @PostMapping("/customers/inquiries/{userId}/optimized")
+    @Operation(summary = "제품 유형별 라인아이템 등록 최적화")
+    public ResponseEntity<JsonResult<?>> processOcrAndChatGpt(
+        @RequestHeader("Authorization") String token,
+        @PathVariable Long userId,
+        @RequestPart(value = "files", required = false) MultipartFile file,
+        @RequestParam("productType") ProductType productType
+    ) {
+        JsonResult<?> response =
+            integratedOcrGptService.processFileAndStructureData(token, userId, file, productType);
+
+        return ResponseEntity.ok(response);
+    }
+
     /* [Start] Dashboard API */
     @GetMapping("/managers/inquiries/dashboard/average-monthly")
     @Operation(summary = "월별 Inquiry 주문 처리 소요일 평균")
@@ -376,19 +391,16 @@ public class InquiryController {
         Map<String, List<Object[]>> response = inquiryService.getInquiryCountsByDepartment(token, date);
         return ResponseEntity.ok(response);
     }
-    /* [End] Dashboard API */
 
-    @PostMapping("/customers/inquiries/{userId}/optimized")
-    @Operation(summary = "제품 유형별 라인아이템 등록 최적화")
-    public ResponseEntity<JsonResult<?>> processOcrAndChatGpt(
+    @GetMapping("managers/inquiries/dashboard/{inquiryId}/logs")
+    @Operation(summary = "Inquiry 진행 상태 히스토리 조회")
+    public ResponseEntity<JsonResult> getInquiryLogs(
         @RequestHeader("Authorization") String token,
-        @PathVariable Long userId,
-        @RequestPart(value = "files", required = false) MultipartFile file,
-        @RequestParam("productType") ProductType productType
+        @PathVariable Long inquiryId
     ) {
-        JsonResult<?> response =
-            integratedOcrGptService.processFileAndStructureData(token, userId, file, productType);
-
-        return ResponseEntity.ok(response);
+        InquiryLogResponseDTO response = inquiryService.getInquiryLogs(token, inquiryId);
+        return ResponseEntity.ok(ResponseFactory.getSuccessJsonResult(response));
     }
+
+    /* [End] Dashboard API */
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/InquiryLogResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/InquiryLogResponseDTO.java
@@ -1,0 +1,38 @@
+package com.pobluesky.backend.domain.inquiry.dto.response;
+
+import com.pobluesky.backend.domain.inquiry.entity.InquiryLog;
+import com.pobluesky.backend.domain.inquiry.entity.Progress;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InquiryLogResponseDTO {
+    private Long inquiryId;
+    private List<ProgressLog> logs;
+
+    @Getter
+    @Builder
+    public static class ProgressLog {
+        private Progress progress;
+        private LocalDateTime timestamp;
+    }
+
+    public static InquiryLogResponseDTO from(Long inquiryId, List<InquiryLog> logs) {
+        List<ProgressLog> logItems = logs.stream()
+            .map(log -> ProgressLog.builder()
+                .progress(log.getProgress())
+                .timestamp(log.getCreatedDate())
+                .build())
+            .collect(Collectors.toList());
+
+        return InquiryLogResponseDTO.builder()
+            .inquiryId(inquiryId)
+            .logs(logItems)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/entity/InquiryLog.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/entity/InquiryLog.java
@@ -1,0 +1,42 @@
+package com.pobluesky.backend.domain.inquiry.entity;
+
+import com.pobluesky.backend.global.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "inquiry_log")
+public class InquiryLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long inquiryLogId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inquiry_id")
+    private Inquiry inquiry;
+
+    @Enumerated(EnumType.STRING)
+    private Progress progress;
+
+    @Builder
+    private InquiryLog(Inquiry inquiry, Progress progress) {
+        this.inquiry = inquiry;
+        this.progress = progress;
+    }
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryLogRepository.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/repository/InquiryLogRepository.java
@@ -1,0 +1,10 @@
+package com.pobluesky.backend.domain.inquiry.repository;
+
+import com.pobluesky.backend.domain.inquiry.entity.InquiryLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryLogRepository extends JpaRepository<InquiryLog, Long> {
+    List<InquiryLog> findByInquiryInquiryIdOrderByCreatedDateAsc(Long inquiryId);
+}

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -29,6 +29,7 @@ import com.pobluesky.backend.domain.user.repository.ManagerRepository;
 import com.pobluesky.backend.domain.user.service.SignService;
 import com.pobluesky.backend.global.error.CommonException;
 import com.pobluesky.backend.global.error.ErrorCode;
+
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -42,8 +43,10 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -294,28 +297,6 @@ public class InquiryService {
 
         return InquiryAllocateResponseDTO.from(inquiry);
     }
-
-//    @Transactional
-//    public InquiryAllocateResponseDTO allocateManager(String token, Long inquiryId) {
-//        Manager manager = validateManager(token);
-//
-//        Inquiry inquiry = inquiryRepository.findById(inquiryId)
-//            .orElseThrow(() -> new CommonException(ErrorCode.INQUIRY_NOT_FOUND));
-//
-//        if (manager.getRole() == UserRole.SALES) {
-//            if (inquiry.getProgress() == Progress.SUBMIT) {
-//                inquiry.allocateSalesManager(manager);
-//                inquiry.updateProgress(Progress.RECEIPT);
-//            } else throw new CommonException(ErrorCode.INQUIRY_UNABLE_ALLOCATE);
-//        } else {
-//            if (inquiry.getProgress() == Progress.QUALITY_REVIEW_REQUEST) {
-//                inquiry.allocateQualityManager(manager);
-//                inquiry.updateProgress(Progress.QUALITY_REVIEW_RESPONSE);
-//            } else throw new CommonException(ErrorCode.INQUIRY_UNABLE_ALLOCATE);
-//        }
-//
-//        return InquiryAllocateResponseDTO.from(inquiry);
-//    }
 
     @Transactional
     public InquiryResponseDTO updateInquiryById(

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/service/InquiryService.java
@@ -7,6 +7,7 @@ import com.pobluesky.backend.domain.inquiry.dto.request.InquiryUpdateRequestDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryAllocateResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryFavoriteLineItemResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryFavoriteResponseDTO;
+import com.pobluesky.backend.domain.inquiry.dto.response.InquiryLogResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryProgressResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquiryResponseDTO;
 import com.pobluesky.backend.domain.inquiry.dto.response.InquirySummaryResponseDTO;
@@ -14,9 +15,11 @@ import com.pobluesky.backend.domain.inquiry.dto.response.MobileInquiryResponseDT
 import com.pobluesky.backend.domain.inquiry.dto.response.MobileInquirySummaryResponseDTO;
 import com.pobluesky.backend.domain.inquiry.entity.Industry;
 import com.pobluesky.backend.domain.inquiry.entity.Inquiry;
+import com.pobluesky.backend.domain.inquiry.entity.InquiryLog;
 import com.pobluesky.backend.domain.inquiry.entity.InquiryType;
 import com.pobluesky.backend.domain.inquiry.entity.ProductType;
 import com.pobluesky.backend.domain.inquiry.entity.Progress;
+import com.pobluesky.backend.domain.inquiry.repository.InquiryLogRepository;
 import com.pobluesky.backend.domain.inquiry.repository.InquiryRepository;
 import com.pobluesky.backend.domain.lineitem.dto.response.LineItemResponseDTO;
 import com.pobluesky.backend.domain.lineitem.service.LineItemService;
@@ -67,6 +70,8 @@ public class InquiryService {
     private final FileService fileService;
 
     private final ManagerRepository managerRepository;
+
+    private final InquiryLogRepository inquiryLogRepository;
 
     // Inquiry 전체 조회(고객사) without paging
     @Transactional(readOnly = true)
@@ -214,6 +219,9 @@ public class InquiryService {
         }
 
         Inquiry savedInquiry = inquiryRepository.save(inquiry);
+
+        // InquiryLog 생성
+        createInquiryLog(savedInquiry, savedInquiry.getProgress());
 
         List<LineItemResponseDTO> lineItems = lineItemService.createLineItems(
             inquiry,
@@ -434,6 +442,9 @@ public class InquiryService {
         )) throw new CommonException(ErrorCode.INVALID_PROGRESS_UPDATE);
 
         inquiry.updateProgress(newProgress);
+
+        // InquiryLog 생성
+        createInquiryLog(inquiry, newProgress);
 
         return InquiryProgressResponseDTO.from(inquiry);
     }
@@ -736,5 +747,25 @@ public class InquiryService {
                 lineItemService.getFullLineItemsByInquiry(inquiryId);
 
         return MobileInquiryResponseDTO.of(inquiry,lineItemsByInquiry);
+    }
+
+    public InquiryLogResponseDTO getInquiryLogs(String token, Long inquiryId) {
+        validateManager(token);
+
+        inquiryRepository.findById(inquiryId)
+            .orElseThrow(() -> new CommonException(ErrorCode.INQUIRY_NOT_FOUND));
+
+        List<InquiryLog> logs = inquiryLogRepository.findByInquiryInquiryIdOrderByCreatedDateAsc(inquiryId);
+
+        return InquiryLogResponseDTO.from(inquiryId, logs);
+    }
+
+    private void createInquiryLog(Inquiry inquiry, Progress progress) {
+        InquiryLog log = InquiryLog.builder()
+            .inquiry(inquiry)
+            .progress(progress)
+            .build();
+
+        inquiryLogRepository.save(log);
     }
 }


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - dashboard 내 `inquiry log` 구현 
  - progress별 inquiry 생성 시점을 담은 별도의 `InquiryLog` entity 생성 
     - inquiry progress update시, progress별 생성 시점을 기록합니다. 
     - Inquiry 엔티티가 진행 상태 및 기타 비즈니스 로직으로 복잡한데, 로그 관리까지 함께 하게 되면 엔티티의 복잡도가 높아질 거 같아 별도로 관리를 분리했습니다. 
     - 다만, MSA분리에 용이할 거 같아 별도의 도메인 폴더를 만들지 않고 inquiry에 함께 넣었습니다.
 - inquiry 수정(2024.09 ~ 2024.10 기준 데이터로 변경) 
 - inquiry_log 데이터 추가(2024.09 ~ 2024.10 기준 데이터로 변경) 

<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
  - [X] [API 명세서 확인](https://jin97.notion.site/inquiry-log-f7099279548a48b8a60e788a3ac902f8?pvs=4)
<br>
