### PR TITLE
pbs-455--refactor: mobile inquiry dto - 담당자, customId 추가

### DIFF
--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/MobileInquiryResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/MobileInquiryResponseDTO.java
@@ -1,12 +1,15 @@
 package com.pobluesky.backend.domain.inquiry.dto.response;
 
-import com.pobluesky.backend.domain.inquiry.entity.*;
+import com.pobluesky.backend.domain.inquiry.entity.Country;
+import com.pobluesky.backend.domain.inquiry.entity.Inquiry;
 import com.pobluesky.backend.domain.lineitem.dto.response.LineItemResponseDTO;
-import com.pobluesky.backend.domain.user.dto.response.ManagerSummaryResponseDTO;
 
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 import java.util.List;
+import java.util.Optional;
 
 @Builder
 public record MobileInquiryResponseDTO(
@@ -19,9 +22,9 @@ public record MobileInquiryResponseDTO(
     String phone,
     Country country,
     String corporate,
-    String  salesPerson,
-    ManagerSummaryResponseDTO salesManagerSummaryDto,
-    ManagerSummaryResponseDTO qualityManagerSummaryDto,
+    String salesPerson,
+    String managerName,
+    String managerDepartment,
     String inquiryType,
     String industry,
     String corporationCode,
@@ -33,13 +36,10 @@ public record MobileInquiryResponseDTO(
     String filePath,
     String responseDeadline,
     List<LineItemResponseDTO> lineItemResponseDTOs,
+    String customInquiryId,
     Boolean isActivated
 ) {
-
-    public static MobileInquiryResponseDTO of(
-        Inquiry inquiry,
-        List<LineItemResponseDTO> lineItemResponseDTOs
-    ) {
+    public static MobileInquiryResponseDTO of(Inquiry inquiry, List<LineItemResponseDTO> lineItemResponseDTOs) {
 
         return MobileInquiryResponseDTO.builder()
             .inquiryId(inquiry.getInquiryId())
@@ -47,22 +47,13 @@ public record MobileInquiryResponseDTO(
             .name(inquiry.getCustomer().getName())
             .customerName(inquiry.getCustomer().getCustomerName())
             .customerCode(inquiry.getCustomer().getCustomerCode())
-            .corporationCode(inquiry.getCustomer().getCustomerCode())
             .email(inquiry.getCustomer().getEmail())
             .phone(inquiry.getCustomer().getPhone())
             .country(inquiry.getCountry())
             .corporate(inquiry.getCorporate())
             .salesPerson(inquiry.getSalesPerson())
-            .salesManagerSummaryDto(
-                ManagerSummaryResponseDTO.from(
-                    inquiry.getSalesManager() != null ? inquiry.getSalesManager() : null
-                )
-            )
-            .qualityManagerSummaryDto(
-                ManagerSummaryResponseDTO.from(
-                    inquiry.getQualityManager() != null ? inquiry.getQualityManager() : null
-                )
-            )
+            .managerName(getManagerName(inquiry))
+            .managerDepartment(getManagerDepartment(inquiry))
             .inquiryType(inquiry.getInquiryType().getKoreanName())
             .industry(inquiry.getIndustry().getKoreanName())
             .corporationCode(inquiry.getCorporationCode())
@@ -74,7 +65,26 @@ public record MobileInquiryResponseDTO(
             .filePath(inquiry.getFilePath())
             .responseDeadline(inquiry.getResponseDeadline())
             .lineItemResponseDTOs(lineItemResponseDTOs)
+            .customInquiryId(generateCustomInquiryId(inquiry.getCreatedDate(), inquiry.getInquiryId()))
             .isActivated(inquiry.getIsActivated())
             .build();
+    }
+
+    private static String getManagerName(Inquiry inquiry) {
+        return Optional.ofNullable(inquiry.getSalesManager())
+            .map(manager -> manager.getName())
+            .orElse(null);
+    }
+
+    private static String getManagerDepartment(Inquiry inquiry) {
+        return Optional.ofNullable(inquiry.getSalesManager())
+            .map(manager -> manager.getDepartment().getName())
+            .orElse(null);
+    }
+
+    static String generateCustomInquiryId(LocalDateTime createdDate, Long inquiryId) {
+        String createdDateString = createdDate.toString();
+
+        return "#" + createdDateString.split("T")[0].replace("-", "") + "P" + inquiryId;
     }
 }

--- a/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/MobileInquirySummaryResponseDTO.java
+++ b/backend/src/main/java/com/pobluesky/backend/domain/inquiry/dto/response/MobileInquirySummaryResponseDTO.java
@@ -4,9 +4,13 @@ import com.pobluesky.backend.domain.inquiry.entity.Inquiry;
 
 import lombok.Builder;
 
+import static com.pobluesky.backend.domain.inquiry.dto.response.MobileInquiryResponseDTO.generateCustomInquiryId;
+
 @Builder
 public record MobileInquirySummaryResponseDTO (
     Long inquiryId,
+
+    String customInquiryId,
 
     String progress,  //진행현황 e.g. 접수 -> 1차검토 -> ..
 
@@ -24,6 +28,7 @@ public record MobileInquirySummaryResponseDTO (
                 .inquiryType(inquiry.getInquiryType().getKoreanName())
                 .customerName(inquiry.getCustomer().getCustomerName())
                 .productType(inquiry.getProductType().toString())
+                .customInquiryId(generateCustomInquiryId(inquiry.getCreatedDate(), inquiry.getInquiryId()))
                 .build();
     }
 
@@ -35,6 +40,7 @@ public record MobileInquirySummaryResponseDTO (
                 .inquiryType(inquirySummary.inquiryType().getKoreanName())
                 .customerName(inquirySummary.customerName())
                 .productType(inquirySummary.productType().toString())
+                .customInquiryId(generateCustomInquiryId(inquirySummary.createdDate(), inquirySummary.inquiryId()))
                 .build();
     }
 }


### PR DESCRIPTION
### Part
  - [ ] FE
  - [X] BE
<br>

### Changes
  - 모바일 custom id 
  - 모바일 담당자명, 부서 
<br>

### Test Checklist ☑️
  - [X] API 데이터 전송 테스트
<br>

### Check point
- 모바일 custom id의 경우 처음부터 모바일 response DTO 에 createdDate가 포함되어 있지 않아
 customId를 서버단에서 조합해서 내려주었습니다.